### PR TITLE
feat: add fixed pin type for fod

### DIFF
--- a/.tack/default.nix
+++ b/.tack/default.nix
@@ -8,6 +8,28 @@ let
 
   fetchPin = name: builtins.fetchTree lock.${name};
 
+  fetchFixed =
+    name: entry:
+    let
+      raw = derivation {
+        inherit name;
+        builder = "builtin:fetchurl";
+        system = "builtin";
+        url = entry.url;
+        outputHash = entry.sha256;
+        outputHashAlgo = "sha256";
+        outputHashMode = "flat";
+      };
+      unpacked = derivation {
+        inherit name;
+        builder = "builtin:unpack-channel";
+        system = "builtin";
+        src = raw;
+        channelName = name;
+      };
+    in
+    if (entry.unpack or "file") == "tarball" then unpacked.outPath + "/" + name else raw.outPath;
+
   resolveSpec = upLock: spec: if builtins.isList spec then walkPath upLock upLock.root spec else spec;
 
   walkPath =
@@ -95,10 +117,22 @@ let
   loadPin =
     name: pin:
     let
-      sourceInfo = fetchPin name;
+      pinType =
+        if pin ? type then
+          pin.type
+        else if pin.flake or true then
+          "flake"
+        else
+          "fetch";
       subdir = if pin ? dir then "/" + pin.dir else "";
     in
-    if pin.flake or true then evalTopFlake sourceInfo pin else sourceInfo.outPath + subdir;
+    if pinType == "fixed" then
+      fetchFixed name lock.${name}
+    else
+      let
+        sourceInfo = fetchPin name;
+      in
+      if pinType == "flake" then evalTopFlake sourceInfo pin else sourceInfo.outPath + subdir;
 
   self = builtins.mapAttrs loadPin pins.inputs;
 in

--- a/README.md
+++ b/README.md
@@ -30,25 +30,37 @@ outputs = { self }:
   };
 ```
 
-the resolver carries a `# tack-managed resolver. delete this line ...`
-marker. any tack command that touches the lock will auto-refresh
-`default.nix` from the running binary's bundled copy while the marker is
-present; remove the marker line to fork the resolver and tack will leave
-it alone.
+tack keeps `default.nix` in sync with the running binary while a
+`tack-managed` comment is present at its top; delete that line to fork
+the resolver.
 
-legacy: existing layouts with `./inputs.nix` at repo root are detected
-and kept as-is. `tack` will read and write the legacy files in place.
+legacy `./inputs.nix` at repo root is detected and preserved as-is.
 
 ## commands
 
 ```
 tack init [--force]
-tack update [names...]   fetch latest, rewrite lock
-tack look [names...]     report pins with newer upstream revs
-tack add <name> <url> [--no-flake] [--dir <d>] [--submodules] [--follows c=p]...
+tack update [names...] [--accept]    fetch latest, rewrite lock
+tack look [names...]                 report pins with newer upstream revs
+tack add <name> <url> [--fetch|--fixed [--unpack tarball|file]]
+                      [--dir <d>] [--submodules] [--follows c=p]...
 tack rm <name>
-tack alias <name> <template>   define a shorturl scheme
-tack alias --rm <name>         remove one
+tack alias <name> <template>         define a shorturl scheme
+tack alias --rm <name>               remove one
+```
+
+## pin types
+
+- `flake` (default) — evaluate the input's `flake.nix`, expose its outputs
+- `fetch` — source tree only, no flake eval. legacy `flake = false`
+- `fixed` — hash-locked download; won't drift, `tack update` refuses to
+  silently relock (use `--accept` if you want to)
+
+```toml
+[inputs.release]
+url = "https://example.com/release-1.2.3.tar.gz"
+type = "fixed"
+# unpack = "tarball" | "file"   # auto-detected from the URL
 ```
 
 ## url schemes

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,11 @@ use anyhow::{
     bail,
 };
 
+use crate::pins::{
+    PinType,
+    Unpack,
+};
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum Command {
     Init {
@@ -21,7 +26,8 @@ pub enum Command {
     Add {
         name:       String,
         url:        String,
-        flake:      bool,
+        pin_type:   PinType,
+        unpack:     Option<Unpack>,
         dir:        Option<String>,
         submodules: bool,
         follows:    Vec<(String, String)>,
@@ -86,13 +92,27 @@ fn parse_parser(mut parser: lexopt::Parser) -> Result<Command> {
         },
         "add" => {
             let (mut name, mut url) = (None, None);
-            let mut flake = true;
+            let mut pin_type = PinType::Flake;
+            let mut unpack: Option<Unpack> = None;
             let mut dir = None;
             let mut submodules = false;
             let mut follows = Vec::new();
-            while let Some(arg) = parser.next()? {
-                match arg {
-                    Long("no-flake") => flake = false,
+            while let Some(a) = p.next()? {
+                match a {
+                    Long("no-flake") => pin_type = PinType::Fetch,
+                    Long("fetch") => pin_type = PinType::Fetch,
+                    Long("fixed") => pin_type = PinType::Fixed,
+                    Long("unpack") => {
+                        let s = p
+                            .value()?
+                            .string()
+                            .map_err(|_| anyhow::anyhow!("bad unpack"))?;
+                        unpack = Some(match s.as_str() {
+                            "tarball" => Unpack::Tarball,
+                            "file" => Unpack::File,
+                            other => bail!("unknown unpack '{other}' (expected tarball|file)"),
+                        });
+                    },
                     Long("submodules") => submodules = true,
                     Long("dir") => {
                         dir = Some(
@@ -127,7 +147,8 @@ fn parse_parser(mut parser: lexopt::Parser) -> Result<Command> {
             Ok(Command::Add {
                 name: name.context("add: missing <name>")?,
                 url: url.context("add: missing <url>")?,
-                flake,
+                pin_type,
+                unpack,
                 dir,
                 submodules,
                 follows,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -24,6 +24,10 @@ use crate::{
     fetch,
     lock,
     pins,
+    pins::{
+        PinType,
+        Unpack,
+    },
     shorturl,
     ui::{
         Display,
@@ -105,6 +109,9 @@ fn short(rev: &str) -> String {
             return seg.chars().take(16).collect();
         }
     }
+    if let Some(b64) = rev.strip_prefix("sha256-") {
+        return format!("sha256-{}", b64.chars().take(12).collect::<String>());
+    }
     rev.chars().take(7).collect()
 }
 
@@ -157,21 +164,31 @@ pub fn init(force: bool) -> Result<()> {
 pub fn add(
     name: &str,
     url: &str,
-    flake: bool,
+    pin_type: PinType,
+    unpack: Option<Unpack>,
     dir_field: Option<&str>,
     submodules: bool,
     follows: &[(String, String)],
 ) -> Result<()> {
-    let dir = dir();
-    let mut doc = pins::load(&pins_path(&dir))?;
+    if unpack.is_some() && pin_type != PinType::Fixed {
+        bail!("--unpack is only valid with --fixed");
+    }
+    let d = dir();
+    let mut doc = pins::load(&pins_path(&d))?;
     if pins::has_input(&doc, name) {
         bail!("input '{name}' already exists");
     }
-    pins::add_input(&mut doc, name, url, flake, dir_field, submodules, follows);
-    pins::save(&pins_path(&dir), &doc)?;
+    pins::add_input(
+        &mut doc, name, url, pin_type, unpack, dir_field, submodules, follows,
+    );
+    pins::save(&pins_path(&d), &doc)?;
 
     let expanded = shorturl::expand(url, &pins::shorturls(&doc));
-    match fetch::fetch_pin(&expanded, submodules) {
+    let fetched = match pin_type {
+        PinType::Fixed => fetch::fetch_fixed_pin(&expanded, unpack),
+        _ => fetch::fetch_pin(&expanded, submodules),
+    };
+    match fetched {
         Ok((node, rev)) => {
             let mut lk = lock::load(&lock_path(&dir))?;
             lk.insert(name.to_owned(), node);
@@ -247,7 +264,39 @@ pub fn update(names: &[String], accept: bool) -> Result<()> {
             let expanded = shorturl::expand(&inp.url, &shorturls);
             let old = lk.get(&inp.name);
             let old_rev = old.and_then(lock::rev_of);
-            match fetch::fetch_pin(&expanded, inp.submodules) {
+            let fetched = match inp.pin_type {
+                PinType::Fixed => fetch::fetch_fixed_pin(&expanded, inp.unpack),
+                _ => fetch::fetch_pin(&expanded, inp.submodules),
+            };
+            match fetched {
+                // for fixed pins sha256 is the identity; any mismatch is drift
+                Ok((node, rev))
+                    if inp.pin_type == PinType::Fixed
+                        && old_rev.is_some()
+                        && old_rev != Some(rev.as_str()) =>
+                {
+                    let old_short = old_rev.map(short).unwrap_or_default();
+                    let new_short = short(&rev);
+                    match accept {
+                        true => {
+                            display.set(i, PinStatus::FixedDrift {
+                                old:      old_short,
+                                new:      new_short,
+                                accepted: true,
+                            });
+                            Some(node)
+                        },
+                        false => {
+                            drift.fetch_add(1, Ordering::Relaxed);
+                            display.set(i, PinStatus::FixedDrift {
+                                old:      old_short,
+                                new:      new_short,
+                                accepted: false,
+                            });
+                            None
+                        },
+                    }
+                },
                 Ok((node, rev)) if old_rev == Some(rev.as_str()) => {
                     // same rev, if hash moved, upstream changed under a stable rev
                     let drifted = matches!(
@@ -308,8 +357,8 @@ pub fn update(names: &[String], accept: bool) -> Result<()> {
 
     if drift.into_inner() > 0 {
         bail!(
-            "locked rev unchanged but upstream content differs (lock kept; investigate before \
-             relocking)"
+            "upstream content differs from lock (lock kept; investigate, then re-run with \
+             --accept to relock)"
         );
     }
     Ok(())
@@ -329,6 +378,13 @@ pub fn look(names: &[String]) -> Result<()> {
     let display = Display::new(selected.iter().map(|i| i.name.clone()).collect());
 
     selected.par_iter().enumerate().for_each(|(i, inp)| {
+        if inp.pin_type == PinType::Fixed {
+            display.set(
+                i,
+                PinStatus::Skipped("fixed pin, run `tack update` to verify".into()),
+            );
+            return;
+        }
         display.set(i, PinStatus::Fetching);
         let expanded = shorturl::expand(&inp.url, &shorturls);
         let old = lk.get(&inp.name).and_then(lock::rev_of).map(str::to_owned);
@@ -373,21 +429,16 @@ usage:
   tack init [--force]
   tack update [names...] [--accept]
   tack look [names...]
-  tack add <name> <url> [--no-flake] [--dir <d>] [--submodules] [--follows c=p]...
+  tack add <name> <url> [--fetch|--fixed [--unpack tarball|file]]
+                        [--dir <d>] [--submodules] [--follows c=p]...
   tack rm <name>
   tack alias <name> <template> | tack alias --rm <name>
 
-tack lives in ./.tack/ by default; legacy root layouts (pins.toml etc. at
-cwd alongside inputs.nix) are detected and kept as-is. TACK_DIR overrides.
+pin types: flake (default), fetch (source tree only), fixed (FOD)
 
-import from your flake/config:
+tack lives in ./.tack/ by default
+use `import ./.tack` to use inputs
 
-  outputs = { self }:
-    let inputs = import ./.tack; in {
-      packages.x86_64-linux.default =
-        inputs.nixpkgs.legacyPackages.x86_64-linux.hello;
-    }};
-
-git flakes only see tracked files, so commit the contents of .tack/"
+"
     );
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -44,7 +44,10 @@ use ureq::{
 };
 use xz2::read::XzDecoder;
 
-use crate::nar;
+use crate::{
+    nar,
+    pins::Unpack,
+};
 
 fn agent() -> &'static Agent {
     static AGENT: OnceLock<Agent> = OnceLock::new();
@@ -159,6 +162,44 @@ pub fn current_rev(expanded: &str) -> Result<String> {
             Ok(immutable_url_of(&resp, &url))
         },
     }
+}
+
+/// Fetch a `fixed` pin: download URL bytes, sha256 them as raw bytes (not NAR),
+/// return the locked node plus the sha256 (used for the drift-display "rev").
+/// Auto-detects `unpack` from URL extension when not supplied.
+pub fn fetch_fixed_pin(url: &str, unpack: Option<Unpack>) -> Result<(Value, String)> {
+    if !url.starts_with("https://") && !url.starts_with("http://") {
+        bail!("fixed pins require a plain http(s) URL, got: {url}");
+    }
+    let resp = agent()
+        .get(url)
+        .set("User-Agent", "tack")
+        .call()
+        .with_context(|| format!("GET {url}"))?;
+    let immutable_url = immutable_url_of(&resp, url);
+    let mut bytes = Vec::new();
+    resp.into_reader()
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("read body of {url}"))?;
+    let sha256 = nar::hash_bytes(&bytes);
+    // detect from the user-supplied URL first; the immutable URL may have lost
+    // the extension via a redirect (e.g. github archives -> codeload)
+    let unpack = unpack.unwrap_or_else(|| {
+        if Unpack::detect(url) == Unpack::Tarball
+            || Unpack::detect(&immutable_url) == Unpack::Tarball
+        {
+            Unpack::Tarball
+        } else {
+            Unpack::File
+        }
+    });
+    let node = json!({
+        "type": "fixed",
+        "url": immutable_url,
+        "sha256": sha256,
+        "unpack": unpack.as_str(),
+    });
+    Ok((node, sha256))
 }
 
 /// fetch the tree, return (locked node, rev)

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -33,13 +33,17 @@ pub fn save(path: &Path, lock: &Lock) -> Result<()> {
 }
 
 pub fn rev_of(node: &Value) -> Option<&str> {
-    if node.get("type").and_then(Value::as_str) == Some("tarball") {
-        node.get("url")?.as_str()
-    } else {
-        node.get("rev")?.as_str()
+    match node.get("type").and_then(Value::as_str) {
+        Some("tarball") => node.get("url")?.as_str(),
+        Some("fixed") => node.get("sha256")?.as_str(),
+        _ => node.get("rev")?.as_str(),
     }
 }
 
 pub fn hash_of(node: &Value) -> Option<&str> {
-    node.get("narHash")?.as_str()
+    if node.get("type").and_then(Value::as_str) == Some("fixed") {
+        node.get("sha256")?.as_str()
+    } else {
+        node.get("narHash")?.as_str()
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,11 +28,22 @@ fn run() -> anyhow::Result<()> {
         Command::Add {
             name,
             url,
-            flake,
+            pin_type,
+            unpack,
             dir,
             submodules,
             follows,
-        } => commands::add(&name, &url, flake, dir.as_deref(), submodules, &follows),
+        } => {
+            commands::add(
+                &name,
+                &url,
+                pin_type,
+                unpack,
+                dir.as_deref(),
+                submodules,
+                &follows,
+            )
+        },
         Command::Rm { name } => commands::rm(&name),
         Command::Alias { name, template, rm } => commands::alias(&name, template.as_deref(), rm),
         Command::Help => {

--- a/src/nar.rs
+++ b/src/nar.rs
@@ -36,9 +36,14 @@ pub fn hash_path(root: &Path) -> Result<String> {
     Ok(format!("sha256-{}", b64(&hash.finalize())))
 }
 
-fn emit_node(hash: &mut Sha256, path: &mut PathBuf) -> Result<()> {
-    let meta = fs::symlink_metadata(&path).with_context(|| format!("stat {}", path.display()))?;
-    emit_bytes(hash, b"(");
+/// sri sha256 of raw bytes; matches what `builtin:fetchurl` checks against
+pub fn hash_bytes(bytes: &[u8]) -> String {
+    format!("sha256-{}", b64(&Sha256::digest(bytes)))
+}
+
+fn emit_node(h: &mut Sha256, path: &Path) -> Result<()> {
+    let meta = fs::symlink_metadata(path).with_context(|| format!("stat {}", path.display()))?;
+    emit_bytes(h, b"(");
     if meta.is_symlink() {
         let target = fs::read_link(&path)?;
         emit_bytes(hash, b"type");

--- a/src/pins.rs
+++ b/src/pins.rs
@@ -18,10 +18,76 @@ use toml_edit::{
     value,
 };
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PinType {
+    Flake,
+    Fetch,
+    Fixed,
+}
+
+impl PinType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Flake => "flake",
+            Self::Fetch => "fetch",
+            Self::Fixed => "fixed",
+        }
+    }
+
+    fn parse(s: &str) -> Result<Self> {
+        match s {
+            "flake" => Ok(Self::Flake),
+            "fetch" => Ok(Self::Fetch),
+            "fixed" => Ok(Self::Fixed),
+            other => bail!("unknown pin type '{other}' (expected flake|fetch|fixed)"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Unpack {
+    Tarball,
+    File,
+}
+
+impl Unpack {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Tarball => "tarball",
+            Self::File => "file",
+        }
+    }
+
+    fn parse(s: &str) -> Result<Self> {
+        match s {
+            "tarball" => Ok(Self::Tarball),
+            "file" => Ok(Self::File),
+            other => bail!("unknown unpack '{other}' (expected tarball|file)"),
+        }
+    }
+
+    /// guess from a URL extension; tarball-family wins, otherwise file
+    pub fn detect(url: &str) -> Self {
+        let path = url.split('?').next().unwrap_or(url);
+        let path = path.split('#').next().unwrap_or(path);
+        let lower = path.to_ascii_lowercase();
+        let tarballish = [
+            ".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz", ".tbz2", ".tar.xz", ".txz",
+        ];
+        if tarballish.iter().any(|s| lower.ends_with(s)) {
+            Self::Tarball
+        } else {
+            Self::File
+        }
+    }
+}
+
 pub struct Input {
     pub name:       String,
     pub url:        String,
     pub submodules: bool,
+    pub pin_type:   PinType,
+    pub unpack:     Option<Unpack>,
 }
 
 pub fn load(path: &Path) -> Result<DocumentMut> {
@@ -65,13 +131,33 @@ pub fn inputs(doc: &DocumentMut) -> Result<Vec<Input>> {
             .get("url")
             .and_then(Item::as_str)
             .with_context(|| format!("input '{name}' has no url"))?;
+        // `type` is canonical; legacy `flake = false` reads as `fetch`
+        let pin_type = match table.get("type").and_then(Item::as_str) {
+            Some(s) => PinType::parse(s).with_context(|| format!("input '{name}'"))?,
+            None => {
+                match table.get("flake").and_then(Item::as_bool) {
+                    Some(false) => PinType::Fetch,
+                    _ => PinType::Flake,
+                }
+            },
+        };
+        let unpack = table
+            .get("unpack")
+            .and_then(Item::as_str)
+            .map(|s| Unpack::parse(s).with_context(|| format!("input '{name}'")))
+            .transpose()?;
+        if pin_type != PinType::Fixed && unpack.is_some() {
+            bail!("input '{name}': `unpack` is only valid for type = \"fixed\"");
+        }
         out.push(Input {
-            name:       name.to_owned(),
-            url:        url.to_owned(),
+            name: name.to_owned(),
+            url: url.to_owned(),
             submodules: entry
                 .get("submodules")
                 .and_then(Item::as_bool)
                 .unwrap_or(false),
+            pin_type,
+            unpack,
         });
     }
     Ok(out)
@@ -87,16 +173,20 @@ pub fn add_input(
     doc: &mut DocumentMut,
     name: &str,
     url: &str,
-    flake: bool,
+    pin_type: PinType,
+    unpack: Option<Unpack>,
     dir: Option<&str>,
     submodules: bool,
     follows: &[(String, String)],
 ) {
-    let mut entry = Table::new();
-    entry.set_implicit(false);
-    entry["url"] = value(url);
-    if !flake {
-        entry["flake"] = value(false);
+    let mut t = Table::new();
+    t.set_implicit(false);
+    t["url"] = value(url);
+    if pin_type != PinType::Flake {
+        t["type"] = value(pin_type.as_str());
+    }
+    if let Some(u) = unpack {
+        t["unpack"] = value(u.as_str());
     }
     if let Some(subdir) = dir {
         entry["dir"] = value(subdir);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -27,8 +27,22 @@ pub enum PinStatus {
     Pending,
     Fetching,
     NoChange,
-    Updated { old: String, new: String },
-    Drift { rev: String, accepted: bool },
+    Updated {
+        old: String,
+        new: String,
+    },
+    Drift {
+        rev:      String,
+        accepted: bool,
+    },
+    /// fixed-pin identity moved; old + new sha256 short forms
+    FixedDrift {
+        old:      String,
+        new:      String,
+        accepted: bool,
+    },
+    /// pin intentionally skipped with a one-line note
+    Skipped(String),
     Failed(String),
 }
 
@@ -119,16 +133,22 @@ fn draw(names: &[String], states: &[PinStatus], frame: usize, drawn: bool) {
 }
 
 fn glyph(st: &PinStatus, frame: usize) -> String {
-    let (color, ch) = match *st {
-        PinStatus::Pending => (2_i32, '\u{b7}'),
-        PinStatus::Fetching => (34_i32, FRAMES[frame % FRAMES.len()]),
-        PinStatus::NoChange => (33_i32, '-'),
-        PinStatus::Updated { .. } => (32_i32, '\u{2713}'),
-        PinStatus::Drift { accepted: true, .. } => (33_i32, '~'),
+    let (color, ch) = match st {
+        PinStatus::Pending => (2, '·'),
+        PinStatus::Fetching => (34, FRAMES[frame % FRAMES.len()]),
+        PinStatus::NoChange => (33, '-'),
+        PinStatus::Updated { .. } => (32, '✓'),
+        PinStatus::Drift { accepted: true, .. } | PinStatus::FixedDrift { accepted: true, .. } => {
+            (33, '~')
+        },
         PinStatus::Drift {
             accepted: false, ..
-        } => (31_i32, '!'),
-        PinStatus::Failed(_) => (31_i32, '\u{2717}'),
+        }
+        | PinStatus::FixedDrift {
+            accepted: false, ..
+        } => (31, '!'),
+        PinStatus::Skipped(_) => (2, '·'),
+        PinStatus::Failed(_) => (31, '✗'),
     };
     format!("\x1b[{color}m{ch}\x1b[0m")
 }
@@ -148,8 +168,25 @@ fn suffix(st: &PinStatus) -> String {
         } => {
             format!("  DRIFT: rev {rev} content changed, relocked (--accept)")
         },
-        PinStatus::Failed(ref msg) => format!("  {msg}"),
-        PinStatus::Pending | PinStatus::Fetching | PinStatus::NoChange => String::new(),
+        PinStatus::FixedDrift {
+            old,
+            new,
+            accepted: false,
+        } => {
+            format!(
+                "  DRIFT: fixed pin sha256 changed {old} -> {new} (lock kept; --accept to relock)"
+            )
+        },
+        PinStatus::FixedDrift {
+            old,
+            new,
+            accepted: true,
+        } => {
+            format!("  DRIFT: fixed pin sha256 changed {old} -> {new}, relocked (--accept)")
+        },
+        PinStatus::Skipped(note) => format!("  {note}"),
+        PinStatus::Failed(msg) => format!("  {msg}"),
+        _ => String::new(),
     }
 }
 
@@ -173,7 +210,27 @@ fn plain_line(name: &str, st: &PinStatus) -> Option<String> {
                 "{name}: DRIFT: rev {rev} content changed, relocked (--accept)"
             ))
         },
-        PinStatus::Failed(ref msg) => Some(format!("{name}: FAILED: {msg}")),
-        PinStatus::Pending | PinStatus::Fetching => None,
+        PinStatus::FixedDrift {
+            old,
+            new,
+            accepted: false,
+        } => {
+            Some(format!(
+                "{name}: DRIFT: fixed pin sha256 changed {old} -> {new} (lock kept; --accept to \
+                 relock)"
+            ))
+        },
+        PinStatus::FixedDrift {
+            old,
+            new,
+            accepted: true,
+        } => {
+            Some(format!(
+                "{name}: DRIFT: fixed pin sha256 changed {old} -> {new}, relocked (--accept)"
+            ))
+        },
+        PinStatus::Skipped(note) => Some(format!("{name}: {note}")),
+        PinStatus::Failed(msg) => Some(format!("{name}: FAILED: {msg}")),
+        _ => None,
     }
 }


### PR DESCRIPTION
this uses builtins:fetchurl and builtins:unpack-channel (originally nix bootstrapping tools) to achieve nixpkgs-less FODs, which are locked by hash and only updatable by explicit `tack update --accept`.