### PR TITLE
fix: only dedup flake pin

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -479,13 +479,14 @@ pub fn dedup(deep: bool) -> Result<()> {
 
     let mut frontier: Vec<TackTransitive> = inputs
         .iter()
-        .filter(|i| i.pin_type != PinType::Fixed)
         .filter_map(|inp| {
             let node = lock.get(&inp.name)?;
-            Some(TackTransitive {
-                path:       vec![inp.name.clone()],
-                source:     SourceRef::Locked(node.clone()),
-                submodules: inp.submodules,
+            (inp.pin_type == PinType::Flake).then(|| {
+                TackTransitive {
+                    path:       vec![inp.name.clone()],
+                    source:     SourceRef::Locked(node.clone()),
+                    submodules: inp.submodules,
+                }
             })
         })
         .collect();


### PR DESCRIPTION
Since only flake type pins are resolved into flake output, I think it makes sense to dedup only those of flake type.

Feel free to dismiss this if you think it does not align with your design.