### PR TITLE
flake: use nightly `rustfmt` in devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
               pkgs.cargo
               pkgs.rustc
               pkgs.clippy
-              pkgs.rustfmt
+              nightlyRustfmt
               pkgs.rust-analyzer
             ]
             ++ nativeDeps pkgs


### PR DESCRIPTION
Since the `rustfmt` binary is from Nixpkgs, you cant do `nix +nightly fmt --all`, and editor's auto format also use the stable formatter and cause huge diff. This would fix that.