### PR TITLE
a bit of breakage with a lot of perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +727,7 @@ name = "tack"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "data-encoding",
  "flate2",
  "git2",
  "lexopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,20 @@ name = "tack"
 path = "src/main.rs"
 
 [dependencies]
-anyhow     = "1.0.102"
-flate2     = "1.1.9"
-git2       = "0.21"
-lexopt     = "0.3.2"
-native-tls = "0.2.18"
-rayon      = "1.12.0"
-serde_json = "1.0.150"
-sha2       = "0.11.0"
-tar        = { default-features = false, version = "0.4.46" }
-tempfile   = "3.27.0"
-toml_edit  = "0.25.12"
-ureq       = { default-features = false, features = [ "native-tls" ], version = "3.3.0" }
-xz2        = "0.1.7"
+anyhow        = "1.0.102"
+data-encoding = "2.10.0"
+flate2        = "1.1.9"
+git2          = "0.21"
+lexopt        = "0.3.2"
+native-tls    = "0.2.18"
+rayon         = "1.12.0"
+serde_json    = "1.0.150"
+sha2          = "0.11.0"
+tar           = { default-features = false, version = "0.4.46" }
+tempfile      = "3.27.0"
+toml_edit     = "0.25.12"
+ureq          = { default-features = false, features = [ "native-tls" ], version = "3.3.0" }
+xz2           = "0.1.7"
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -47,13 +47,12 @@ tack add <name> <url> [--fetch|--fixed [--unpack tarball|file]]
 tack rm <name>
 tack alias <name> <template>         define a shorturl scheme
 tack alias --rm <name>               remove one
-tack dedup [--deep]                  report inputs reachable from multiple pins
+tack dedup                           report inputs reachable from multiple pins
 ```
 
-`tack dedup` reports inputs reachable from more than one of your pins —
-direct or transitive. when a top-level pin matches, it suggests a
-`[all_follow]` rule to share it. `--deep` recurses through the pins of your
-pins and so on indefinitely.
+`tack dedup` reports inputs reachable from more than one of your pins, whether
+direct or transitive, and recurses through the pins of your pins indefinitely.
+when a top-level pin matches, it suggests an `[all_follow]` rule to share it.
 
 ## pin types
 

--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,8 @@
       inputs = import ./.tack;
       inherit (inputs) nixpkgs fenix;
       inherit (nixpkgs) lib;
-      forAllSystems = lib.genAttrs lib.systems.flakeExposed;
-      pkgsFor = system: nixpkgs.legacyPackages.${system};
+      forAllSystems = lib.genAttrs (lib.systems.doubles.linux ++ lib.systems.doubles.darwin);
+      pkgsFor = system: nixpkgs.legacyPackages.${system} or (import nixpkgs { inherit system; });
 
       # wild + clang are only used on Linux tier-1 arches
       hasWild = plat: plat.isLinux && (plat.isx86_64 || plat.isAarch64);
@@ -38,29 +38,7 @@
         {
           default = self.packages.${system}.tack;
 
-          tack = pkgs.rustPlatform.buildRustPackage {
-            pname = "tack";
-            version = "0.1.0";
-            src = ./.;
-            cargoLock.lockFile = ./Cargo.lock;
-
-            nativeBuildInputs = nativeDeps pkgs;
-            buildInputs = linkDeps pkgs;
-
-            # link nixpkgs c libs, no vendored copies.
-            env = {
-              LIBGIT2_NO_VENDOR = 1;
-              OPENSSL_NO_VENDOR = 1;
-            }
-            // lib.optionalAttrs (hasWild pkgs.stdenv.hostPlatform) {
-              RUSTFLAGS = "-Clinker=${pkgs.clang}/bin/clang -Clink-arg=--ld-path=wild";
-            };
-
-            meta = {
-              description = "flake-like toml nix pins, lazily fetched and transformed";
-              mainProgram = "tack";
-            };
-          };
+          tack = pkgs.callPackage ./nix/package.nix { };
         }
       );
 

--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,10 @@
           nightlyRustfmt = fenix.packages.${system}.latest.rustfmt;
         in
         {
-          default = self.checks.${system}.fmt;
+          default = pkgs.linkFarmFromDrvs "tack-checks" [
+            self.checks.${system}.fmt
+            self.checks.${system}.clippy
+          ];
           fmt =
             pkgs.runCommand "tack-fmt-check"
               {
@@ -134,6 +137,22 @@
                 find . -name '*.nix' -exec nixfmt --check {} +
                 touch $out
               '';
+          clippy = self.packages.${system}.tack.overrideAttrs (old: {
+            pname = "tack-clippy";
+            nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.clippy ];
+            buildPhase = ''
+              runHook preBuild
+              cargo clippy --all-targets --offline -- -D warnings
+              runHook postBuild
+            '';
+            checkPhase = "true";
+            doCheck = false;
+            installPhase = ''
+              runHook preInstall
+              touch $out
+              runHook postInstall
+            '';
+          });
         }
       );
     };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: EUPL-1.2
+{
+  lib,
+  rustPlatform,
+  stdenv,
+  pkg-config,
+  openssl,
+  libgit2,
+  libssh2,
+  zlib,
+  clang,
+  wild ? null,
+}:
+let
+  # wild + clang are only used on Linux tier-1 arches
+  hasWild =
+    stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isAarch64);
+in
+rustPlatform.buildRustPackage {
+  pname = "tack";
+  version = (lib.importTOML ../Cargo.toml).package.version;
+  src = ../.;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = [
+    pkg-config
+  ]
+  ++ lib.optionals hasWild [
+    wild
+    clang
+  ];
+  buildInputs = [
+    openssl
+    libgit2
+    libssh2
+    zlib
+  ];
+
+  # link nixpkgs c libs, no vendored copies.
+  env = {
+    LIBGIT2_NO_VENDOR = 1;
+    OPENSSL_NO_VENDOR = 1;
+  }
+  // lib.optionalAttrs hasWild {
+    RUSTFLAGS = "-Clinker=${clang}/bin/clang -Clink-arg=--ld-path=wild";
+  };
+
+  meta = {
+    description = "flake-like toml nix pins, lazily fetched and transformed";
+    mainProgram = "tack";
+  };
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,8 +102,7 @@ fn parse_parser(mut parser: lexopt::Parser) -> Result<Command> {
             let mut follows = Vec::new();
             while let Some(arg) = parser.next()? {
                 match arg {
-                    Long("no-flake") => pin_type = PinType::Fetch,
-                    Long("fetch") => pin_type = PinType::Fetch,
+                    Long("fetch" | "no-flake") => pin_type = PinType::Fetch,
                     Long("fixed") => pin_type = PinType::Fixed,
                     Long("unpack") => {
                         let value = parser

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,9 +40,7 @@ pub enum Command {
         template: Option<String>,
         rm:       bool,
     },
-    Dedup {
-        deep: bool,
-    },
+    Dedup,
     Help,
 }
 
@@ -198,14 +196,10 @@ fn parse_parser(mut parser: lexopt::Parser) -> Result<Command> {
             Ok(Command::Alias { name, template, rm })
         },
         "dedup" => {
-            let mut deep = false;
-            while let Some(arg) = parser.next()? {
-                match arg {
-                    Long("deep") => deep = true,
-                    Short(_) | Long(_) | Value(_) => return Err(arg.unexpected().into()),
-                }
+            if let Some(arg) = parser.next()? {
+                return Err(arg.unexpected().into());
             }
-            Ok(Command::Dedup { deep })
+            Ok(Command::Dedup)
         },
         _ => Ok(Command::Help),
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,9 @@ use std::{
         BTreeSet,
         HashSet,
     },
+    env,
     fs,
+    mem,
     path::{
         Path,
         PathBuf,
@@ -45,10 +47,10 @@ const RESOLVER_NIX: &str = include_str!("../.tack/default.nix");
 const MARKER: &str = "# tack-managed resolver.";
 
 fn dir() -> PathBuf {
-    if let Some(d) = std::env::var_os("TACK_DIR") {
-        return PathBuf::from(d);
+    if let Some(dir) = env::var_os("TACK_DIR") {
+        return PathBuf::from(dir);
     }
-    let cwd = std::env::current_dir().expect("cwd");
+    let cwd = env::current_dir().expect("cwd");
     if cwd.join("inputs.nix").exists() {
         return cwd;
     }
@@ -74,17 +76,14 @@ fn resolver_path(dir: &Path) -> PathBuf {
 
 /// rewrite the resolver if it carries the management marker AND its bytes
 /// differ from the bundled template; leave it alone otherwise.
-fn refresh_resolver(d: &Path) {
-    let rp = resolver_path(d);
-    match std::fs::read_to_string(&rp) {
-        Ok(current) => {
-            if current.contains(MARKER) && current != RESOLVER_NIX {
-                let _ = write_atomic(&rp, RESOLVER_NIX);
-            }
-        },
-        Err(_) => {
-            // resolver missing — let init/etc. handle it; not our job here
-        },
+fn refresh_resolver(dir: &Path) {
+    let rp = resolver_path(dir);
+    if let Ok(current) = fs::read_to_string(&rp) {
+        if current.contains(MARKER) && current != RESOLVER_NIX {
+            let _ = write_atomic(&rp, RESOLVER_NIX);
+        }
+    } else {
+        // resolver missing — let init/etc. handle it; not our job here
     }
 }
 
@@ -139,7 +138,7 @@ pub fn init(force: bool) -> Result<()> {
             bail!("{} already exists (use --force)", clash.join(", "));
         }
     }
-    std::fs::create_dir_all(&dir)?;
+    fs::create_dir_all(&dir)?;
     write_atomic(&pt, STARTER_TOML)?;
     if !lp.exists() {
         write_atomic(&lp, "{}\n")?;
@@ -170,15 +169,19 @@ pub fn add(
     if pins::has_input(&doc, name) {
         bail!("input '{name}' already exists");
     }
-    pins::add_input(
-        &mut doc, name, url, pin_type, unpack, dir_field, submodules, follows,
-    );
+    pins::add_input(&mut doc, name, url, &pins::AddInputOpts {
+        pin_type,
+        unpack,
+        dir: dir_field,
+        submodules,
+        follows,
+    });
     pins::save(&pins_path(&dir), &doc)?;
 
     let expanded = shorturl::expand(url, &pins::shorturls(&doc));
     let fetched = match pin_type {
         PinType::Fixed => fetch::fetch_fixed_pin(&expanded, unpack),
-        _ => fetch::fetch_pin(&expanded, submodules),
+        PinType::Flake | PinType::Fetch => fetch::fetch_pin(&expanded, submodules),
     };
     match fetched {
         Ok((node, rev)) => {
@@ -258,7 +261,7 @@ pub fn update(names: &[String], accept: bool) -> Result<()> {
             let old_rev = old.and_then(lock::rev_of);
             let fetched = match inp.pin_type {
                 PinType::Fixed => fetch::fetch_fixed_pin(&expanded, inp.unpack),
-                _ => fetch::fetch_pin(&expanded, inp.submodules),
+                PinType::Flake | PinType::Fetch => fetch::fetch_pin(&expanded, inp.submodules),
             };
             match fetched {
                 // for fixed pins sha256 is the identity; any mismatch is drift
@@ -267,26 +270,16 @@ pub fn update(names: &[String], accept: bool) -> Result<()> {
                         && old_rev.is_some()
                         && old_rev != Some(rev.as_str()) =>
                 {
-                    let old_short = old_rev.map(short).unwrap_or_default();
-                    let new_short = short(&rev);
-                    match accept {
-                        true => {
-                            display.set(i, PinStatus::FixedDrift {
-                                old:      old_short,
-                                new:      new_short,
-                                accepted: true,
-                            });
-                            Some(node)
-                        },
-                        false => {
-                            drift.fetch_add(1, Ordering::Relaxed);
-                            display.set(i, PinStatus::FixedDrift {
-                                old:      old_short,
-                                new:      new_short,
-                                accepted: false,
-                            });
-                            None
-                        },
+                    display.set(i, PinStatus::FixedDrift {
+                        old:      old_rev.map(short).unwrap_or_default(),
+                        new:      short(&rev),
+                        accepted: accept,
+                    });
+                    if accept {
+                        Some(node)
+                    } else {
+                        drift.fetch_add(1, Ordering::Relaxed);
+                        None
                     }
                 },
                 Ok((node, rev)) if old_rev == Some(rev.as_str()) => {
@@ -295,28 +288,20 @@ pub fn update(names: &[String], accept: bool) -> Result<()> {
                         (old.and_then(lock::hash_of), lock::hash_of(&node)),
                         (Some(prev), Some(curr)) if prev != curr
                     );
-                    match (drifted, accept) {
-                        // relock to the drifted tree, the user vouched for it
-                        (true, true) => {
-                            display.set(i, PinStatus::Drift {
-                                rev:      short(&rev),
-                                accepted: true,
-                            });
+                    if drifted {
+                        display.set(i, PinStatus::Drift {
+                            rev:      short(&rev),
+                            accepted: accept,
+                        });
+                        if accept {
                             Some(node)
-                        },
-                        // trip the alarm and keep the locked node
-                        (true, false) => {
+                        } else {
                             drift.fetch_add(1, Ordering::Relaxed);
-                            display.set(i, PinStatus::Drift {
-                                rev:      short(&rev),
-                                accepted: false,
-                            });
                             None
-                        },
-                        (false, _) => {
-                            display.set(i, PinStatus::NoChange);
-                            None
-                        },
+                        }
+                    } else {
+                        display.set(i, PinStatus::NoChange);
+                        None
                     }
                 },
                 Ok((node, rev)) => {
@@ -484,7 +469,7 @@ pub fn dedup(deep: bool) -> Result<()> {
     let mut visited = HashSet::<String>::new();
     while !frontier.is_empty() {
         let mut batch = Vec::<TackTransitive>::with_capacity(frontier.len());
-        for item in frontier.drain(..) {
+        for item in mem::take(&mut frontier) {
             if visited.insert(source_key(&item.source)) {
                 batch.push(item);
             }
@@ -501,8 +486,11 @@ pub fn dedup(deep: bool) -> Result<()> {
         for (path, res) in results {
             match res {
                 Ok(scan) => {
-                    for f in scan.findings {
-                        groups.entry(f.identity).or_default().push(f.entry);
+                    for finding in scan.findings {
+                        groups
+                            .entry(finding.identity)
+                            .or_default()
+                            .push(finding.entry);
                     }
                     if deep {
                         frontier.extend(scan.transitive);
@@ -523,14 +511,14 @@ pub fn dedup(deep: bool) -> Result<()> {
 
 fn fetch_and_scan(item: &TackTransitive) -> Result<ScanResult> {
     let tmp = tempfile::tempdir()?;
-    let root = match &item.source {
-        SourceRef::Locked(node) => fetch::fetch_locked_tree_into(node, tmp.path())?,
-        SourceRef::Url(url) => fetch::fetch_tree_into(url, item.submodules, tmp.path())?,
+    let root = match item.source {
+        SourceRef::Locked(ref node) => fetch::fetch_locked_tree_into(node, tmp.path())?,
+        SourceRef::Url(ref url) => fetch::fetch_tree_into(url, item.submodules, tmp.path())?,
     };
-    scan_tree(&root, &item.path)
+    Ok(scan_tree(&root, &item.path))
 }
 
-fn scan_tree(root: &Path, path: &[String]) -> Result<ScanResult> {
+fn scan_tree(root: &Path, path: &[String]) -> ScanResult {
     let mut findings = Vec::<Finding>::new();
     let mut transitive = Vec::<TackTransitive>::new();
     let parent_label = format!("via {}", path.join(" > "));
@@ -585,10 +573,11 @@ fn scan_tree(root: &Path, path: &[String]) -> Result<ScanResult> {
             if tinp.pin_type != PinType::Fixed {
                 let mut next = path.to_vec();
                 next.push(tinp.name.clone());
-                let source = match tlock.get(&tinp.name) {
-                    Some(node) => SourceRef::Locked(node.clone()),
-                    None => SourceRef::Url(expanded),
-                };
+                let source = tlock
+                    .get(&tinp.name)
+                    .map_or(SourceRef::Url(expanded), |node| {
+                        SourceRef::Locked(node.clone())
+                    });
                 transitive.push(TackTransitive {
                     path: next,
                     source,
@@ -598,10 +587,10 @@ fn scan_tree(root: &Path, path: &[String]) -> Result<ScanResult> {
         }
     }
 
-    Ok(ScanResult {
+    ScanResult {
         findings,
         transitive,
-    })
+    }
 }
 
 fn find_tack_dir(root: &Path) -> Option<PathBuf> {
@@ -618,8 +607,8 @@ fn find_tack_dir(root: &Path) -> Option<PathBuf> {
 
 fn canonical_identity(expanded: &str) -> Option<String> {
     let no_query = expanded.split('?').next().unwrap_or(expanded);
-    let no_query = no_query.split('#').next().unwrap_or(no_query);
-    if let Some(body) = no_query.strip_prefix("github:") {
+    let path = no_query.split('#').next().unwrap_or(no_query);
+    if let Some(body) = path.strip_prefix("github:") {
         let mut segs = body.split('/');
         let owner = segs.next()?;
         let repo = segs.next()?;
@@ -628,11 +617,11 @@ fn canonical_identity(expanded: &str) -> Option<String> {
         }
         return Some(format!("github:{owner}/{repo}"));
     }
-    if let Some(rest) = no_query.strip_prefix("git+") {
+    if let Some(rest) = path.strip_prefix("git+") {
         return Some(format!("git+{rest}"));
     }
-    if no_query.starts_with("http://") || no_query.starts_with("https://") {
-        return Some(format!("tarball:{no_query}"));
+    if path.starts_with("http://") || path.starts_with("https://") {
+        return Some(format!("tarball:{path}"));
     }
     None
 }
@@ -658,9 +647,9 @@ fn node_identity(locked: &Value) -> Option<String> {
 }
 
 fn source_key(source: &SourceRef) -> String {
-    match source {
-        SourceRef::Locked(node) => node_identity(node).unwrap_or_else(|| node.to_string()),
-        SourceRef::Url(url) => url.clone(),
+    match *source {
+        SourceRef::Locked(ref node) => node_identity(node).unwrap_or_else(|| node.to_string()),
+        SourceRef::Url(ref url) => url.clone(),
     }
 }
 
@@ -687,7 +676,7 @@ fn strip_disambiguator(key: &str) -> &str {
         i -= 1;
     }
     if i > 0 && i < bytes.len() && bytes[i - 1] == b'_' {
-        &key[..i - 1]
+        key.get(..i - 1).unwrap_or(key)
     } else {
         key
     }
@@ -713,7 +702,7 @@ fn print_groups(
         .map(|i| i.name.as_str())
         .collect::<HashSet<&str>>();
     let mut suggest = BTreeSet::<String>::new();
-    let mut printed = 0usize;
+    let mut printed = 0_usize;
 
     for (id, entries) in groups {
         if entries.len() < 2 {
@@ -721,26 +710,34 @@ fn print_groups(
         }
         printed += 1;
         println!("\n{id}  x{}", entries.len());
-        let pw = entries.iter().map(|e| e.parent.len()).max().unwrap_or(0);
-        let nw = entries.iter().map(|e| e.name.len()).max().unwrap_or(0);
-        for e in entries {
+        let pw = entries
+            .iter()
+            .map(|entry| entry.parent.len())
+            .max()
+            .unwrap_or(0);
+        let nw = entries
+            .iter()
+            .map(|entry| entry.name.len())
+            .max()
+            .unwrap_or(0);
+        for entry in entries {
             println!(
                 "  {:pw$}  {:nw$}  {}",
-                e.parent,
-                e.name,
-                e.rev,
+                entry.parent,
+                entry.name,
+                entry.rev,
                 pw = pw,
                 nw = nw
             );
         }
-        let has_top = entries.iter().any(|e| e.parent == "top");
+        let has_top = entries.iter().any(|entry| entry.parent == "top");
         if has_top {
-            for e in entries {
-                if e.parent != "top"
-                    && top_names.contains(e.name.as_str())
-                    && !configured.contains(&e.name)
+            for entry in entries {
+                if entry.parent != "top"
+                    && top_names.contains(entry.name.as_str())
+                    && !configured.contains(&entry.name)
                 {
-                    suggest.insert(e.name.clone());
+                    suggest.insert(entry.name.clone());
                 }
             }
         }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -49,9 +49,6 @@ fn dir() -> PathBuf {
         return PathBuf::from(d);
     }
     let cwd = std::env::current_dir().expect("cwd");
-    if cwd.join(".tack").is_dir() {
-        return cwd.join(".tack");
-    }
     if cwd.join("inputs.nix").exists() {
         return cwd;
     }
@@ -65,14 +62,14 @@ fn lock_path(dir: &Path) -> PathBuf {
     dir.join("pins.lock.json")
 }
 
-/// resolver lives next to pins.toml; legacy root-mode keeps the historical
-/// `inputs.nix` name, otherwise the new convention is `default.nix`.
-fn resolver_path(d: &Path) -> PathBuf {
-    let legacy = d.join("inputs.nix");
+/// resolver is `default.nix` in the modern `.tack/` layout, or `inputs.nix`
+/// when the dir is a repo root carrying the legacy layout
+fn resolver_path(dir: &Path) -> PathBuf {
+    let legacy = dir.join("inputs.nix");
     if legacy.exists() {
         return legacy;
     }
-    d.join("default.nix")
+    dir.join("default.nix")
 }
 
 /// rewrite the resolver if it carries the management marker AND its bytes
@@ -149,20 +146,10 @@ pub fn init(force: bool) -> Result<()> {
     }
     write_atomic(&rp, RESOLVER_NIX)?;
 
-    let resolver_name = rp
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("default.nix");
-    let import_hint = if dir.ends_with(".tack") {
-        "import ./.tack".to_string()
-    } else {
-        format!("import ./{resolver_name}")
-    };
-
     println!("initialised tack in {}", dir.display());
     println!("  pins.toml       edit shorturls and inputs here");
     println!("  pins.lock.json  written by `tack update`");
-    println!("  {resolver_name:<14}  `{import_hint}` from your flake/config");
+    println!("  default.nix     `import ./.tack` from your flake/config");
     Ok(())
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -468,20 +468,13 @@ pub fn dedup(deep: bool) -> Result<()> {
     // batch in parallel, then expand into the next frontier (deep only).
     let mut visited = HashSet::<String>::new();
     while !frontier.is_empty() {
-        let mut batch = Vec::<TackTransitive>::with_capacity(frontier.len());
-        for item in mem::take(&mut frontier) {
-            if visited.insert(source_key(&item.source)) {
-                batch.push(item);
-            }
-        }
-
-        let results = batch
+        let results = mem::take(&mut frontier)
+            .into_iter()
+            .filter(|item| visited.insert(source_key(&item.source)))
+            .collect::<Vec<_>>()
             .into_par_iter()
-            .map(|item| {
-                let res = fetch_and_scan(&item);
-                (item.path, res)
-            })
-            .collect::<Vec<(Vec<String>, Result<ScanResult>)>>();
+            .map(|item| (item.path.clone(), fetch_and_scan(&item)))
+            .collect::<Vec<_>>();
 
         for (path, res) in results {
             match res {
@@ -510,6 +503,18 @@ pub fn dedup(deep: bool) -> Result<()> {
 }
 
 fn fetch_and_scan(item: &TackTransitive) -> Result<ScanResult> {
+    // fetch only the 3 files scan needs via http if the source's forge supports it
+    if let SourceRef::Locked(ref node) = item.source
+        && let Some((flake_lock, tack_pins, tack_lock)) = try_raw_files(node)
+    {
+        return Ok(scan_files(
+            flake_lock.as_deref(),
+            tack_pins.as_deref(),
+            tack_lock.as_deref(),
+            &item.path,
+        ));
+    }
+
     let tmp = tempfile::tempdir()?;
     let root = match item.source {
         SourceRef::Locked(ref node) => fetch::fetch_locked_tree_into(node, tmp.path())?,
@@ -518,13 +523,118 @@ fn fetch_and_scan(item: &TackTransitive) -> Result<ScanResult> {
     Ok(scan_tree(&root, &item.path))
 }
 
+/// `authoritative = true` means a 404 on every probe is final, and `false`
+/// means the caller should fall back to clone
+fn try_raw_files(node: &Value) -> Option<(Option<String>, Option<String>, Option<String>)> {
+    let rev = node.get("rev").and_then(Value::as_str)?;
+    let (base, authoritative) = match node.get("type").and_then(Value::as_str)? {
+        "github" => {
+            let owner = node.get("owner").and_then(Value::as_str)?;
+            let repo = node.get("repo").and_then(Value::as_str)?;
+            (
+                format!("https://raw.githubusercontent.com/{owner}/{repo}"),
+                true,
+            )
+        },
+        "gitlab" => {
+            let owner = node.get("owner").and_then(Value::as_str)?;
+            let repo = node.get("repo").and_then(Value::as_str)?;
+            let host = node
+                .get("host")
+                .and_then(Value::as_str)
+                .unwrap_or("gitlab.com");
+            (format!("https://{host}/{owner}/{repo}"), true)
+        },
+        "git" => {
+            let url = node.get("url").and_then(Value::as_str)?;
+            (url.strip_suffix(".git").unwrap_or(url).to_owned(), false)
+        },
+        _ => return None,
+    };
+
+    let fetch_file = |file: &str| {
+        let (url, decoder) = forge_raw(&base, rev, file);
+        let body = fetch::raw(&url).ok()?;
+        if let Some(decode) = decoder {
+            decode(&body).ok()
+        } else {
+            Some(body)
+        }
+    };
+    let triple = (
+        fetch_file("flake.lock"),
+        fetch_file(".tack/pins.toml"),
+        fetch_file(".tack/pins.lock.json"),
+    );
+    if !authoritative && triple.0.is_none() && triple.1.is_none() && triple.2.is_none() {
+        None
+    } else {
+        Some(triple)
+    }
+}
+
+/// body decoder applied after the http get
+type Decoder = fn(&str) -> Result<String>;
+
+/// map a repo base url + rev + file path to (raw-file url, optional decoder)
+fn forge_raw(base: &str, rev: &str, file: &str) -> (String, Option<Decoder>) {
+    let host = base
+        .split("://")
+        .nth(1)
+        .and_then(|rest| rest.split('/').next())
+        .unwrap_or("");
+    if host == "raw.githubusercontent.com" {
+        (format!("{base}/{rev}/{file}"), None)
+    } else if host == "gitlab.com" || host.starts_with("gitlab.") {
+        (format!("{base}/-/raw/{rev}/{file}"), None)
+    } else if host == "bitbucket.org" {
+        (format!("{base}/raw/{rev}/{file}"), None)
+    } else if host.starts_with("cgit.") || host == "git.kernel.org" {
+        (format!("{base}/plain/{file}?id={rev}"), None)
+    } else if host.ends_with(".googlesource.com") || host.starts_with("gerrit.") {
+        // gerrit/gitiles returns base64-encoded text under ?format=TEXT
+        (
+            format!("{base}/+/{rev}/{file}?format=TEXT"),
+            Some(decode_b64),
+        )
+    } else {
+        // forgejo / gitea / codeberg / unknown self-hosted
+        (format!("{base}/raw/commit/{rev}/{file}"), None)
+    }
+}
+
+fn decode_b64(body: &str) -> Result<String> {
+    let bytes = data_encoding::BASE64
+        .decode(body.trim().as_bytes())
+        .map_err(|err| anyhow::anyhow!("base64 decode: {err}"))?;
+    String::from_utf8(bytes).map_err(|err| anyhow::anyhow!("utf-8 decode: {err}"))
+}
+
 fn scan_tree(root: &Path, path: &[String]) -> ScanResult {
+    let flake_lock = fs::read_to_string(root.join("flake.lock")).ok();
+    let td = root.join(".tack");
+    let tack_pins = fs::read_to_string(td.join("pins.toml")).ok();
+    let tack_lock = fs::read_to_string(td.join("pins.lock.json")).ok();
+    scan_files(
+        flake_lock.as_deref(),
+        tack_pins.as_deref(),
+        tack_lock.as_deref(),
+        path,
+    )
+}
+
+fn scan_files(
+    flake_lock: Option<&str>,
+    tack_pins: Option<&str>,
+    tack_lock: Option<&str>,
+    path: &[String],
+) -> ScanResult {
     let mut findings = Vec::<Finding>::new();
     let mut transitive = Vec::<TackTransitive>::new();
     let parent_label = format!("via {}", path.join(" > "));
 
-    if let Ok(raw) = fs::read_to_string(root.join("flake.lock"))
-        && let Ok(json) = serde_json::from_str::<Value>(&raw)
+    if let Some(raw) = flake_lock
+        && let Ok(json) = serde_json::from_str::<Value>(raw)
     {
         let root_key = json.get("root").and_then(Value::as_str).unwrap_or("root");
         if let Some(nodes) = json.get("nodes").and_then(Value::as_object) {
@@ -549,11 +659,13 @@ fn scan_tree(root: &Path, path: &[String]) -> ScanResult {
         }
     }
 
-    if let Some(td) = find_tack_dir(root)
-        && let Ok(doc) = pins::load(&td.join("pins.toml"))
+    if let Some(raw) = tack_pins
+        && let Ok(doc) = pins::parse_doc(raw)
         && let Ok(tinputs) = pins::inputs(&doc)
     {
-        let tlock = lock::load(&td.join("pins.lock.json")).unwrap_or_default();
+        let tlock = tack_lock
+            .and_then(|str| lock::parse(str).ok())
+            .unwrap_or_default();
         let tshort = pins::shorturls(&doc);
         for tinp in &tinputs {
             let expanded = shorturl::expand(&tinp.url, &tshort);
@@ -591,18 +703,6 @@ fn scan_tree(root: &Path, path: &[String]) -> ScanResult {
         findings,
         transitive,
     }
-}
-
-fn find_tack_dir(root: &Path) -> Option<PathBuf> {
-    let new_layout = root.join(".tack");
-    if new_layout.join("pins.toml").exists() {
-        return Some(new_layout);
-    }
-    // legacy: pins.toml + inputs.nix at repo root
-    if root.join("pins.toml").exists() && root.join("inputs.nix").exists() {
-        return Some(root.to_owned());
-    }
-    None
 }
 
 fn canonical_identity(expanded: &str) -> Option<String> {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -424,7 +424,7 @@ enum SourceRef {
     Url(String),
 }
 
-pub fn dedup(deep: bool) -> Result<()> {
+pub fn dedup() -> Result<()> {
     let dir = dir();
     let doc = pins::load(&pins_path(&dir))?;
     let lock = lock::load(&lock_path(&dir))?;
@@ -465,7 +465,7 @@ pub fn dedup(deep: bool) -> Result<()> {
     eprintln!("scanning {} pin(s)...", frontier.len());
 
     // bfs level-by-level: dedup the frontier against `visited`, fetch the
-    // batch in parallel, then expand into the next frontier (deep only).
+    // batch in parallel, then expand into the next frontier
     let mut visited = HashSet::<String>::new();
     while !frontier.is_empty() {
         let results = mem::take(&mut frontier)
@@ -485,16 +485,10 @@ pub fn dedup(deep: bool) -> Result<()> {
                             .or_default()
                             .push(finding.entry);
                     }
-                    if deep {
-                        frontier.extend(scan.transitive);
-                    }
+                    frontier.extend(scan.transitive);
                 },
                 Err(err) => eprintln!("tack: scan {}: {err:#}", path.join(" > ")),
             }
-        }
-
-        if !deep {
-            break;
         }
     }
 
@@ -868,7 +862,7 @@ usage:
                         [--dir <d>] [--submodules] [--follows c=p]...
   tack rm <name>
   tack alias <name> <template> | tack alias --rm <name>
-  tack dedup [--deep]
+  tack dedup
 
 pin types: flake (default), fetch (source tree only), fixed (FOD)
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -185,7 +185,7 @@ pub fn fetch_fixed_pin(url: &str, unpack: Option<Unpack>) -> Result<(Value, Stri
     let sha256 = nar::hash_bytes(&bytes);
     // detect from the user-supplied URL first; the immutable URL may have lost
     // the extension via a redirect (e.g. github archives -> codeload)
-    let unpack = unpack.unwrap_or_else(|| {
+    let kind = unpack.unwrap_or_else(|| {
         if Unpack::detect(url) == Unpack::Tarball
             || Unpack::detect(&immutable_url) == Unpack::Tarball
         {
@@ -198,7 +198,7 @@ pub fn fetch_fixed_pin(url: &str, unpack: Option<Unpack>) -> Result<(Value, Stri
         "type": "fixed",
         "url": immutable_url,
         "sha256": sha256,
-        "unpack": unpack.as_str(),
+        "unpack": kind.as_str(),
     });
     Ok((node, sha256))
 }
@@ -568,6 +568,8 @@ fn full_ref(reff: Option<&str>, default: impl FnOnce() -> Option<String>) -> Str
 }
 
 fn callbacks() -> RemoteCallbacks<'static> {
+    const NAMES: &[&str] = &["id_ed25519", "id_ecdsa", "id_rsa", "id_dsa"];
+
     let mut cb = RemoteCallbacks::new();
     let mut tried_agent = false;
     let mut key_idx = 0_usize;
@@ -589,9 +591,8 @@ fn callbacks() -> RemoteCallbacks<'static> {
         }
         let ssh_dir = env::var_os("HOME")
             .map(PathBuf::from)
-            .map(|h| h.join(".ssh"))
+            .map(|home| home.join(".ssh"))
             .ok_or_else(|| git2::Error::from_str("ssh: $HOME unset, cannot locate keys"))?;
-        const NAMES: &[&str] = &["id_ed25519", "id_ecdsa", "id_rsa", "id_dsa"];
         while key_idx < NAMES.len() {
             let path = ssh_dir.join(NAMES[key_idx]);
             key_idx += 1;

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -483,6 +483,25 @@ fn gh_commit(owner: &str, repo: &str, reff: &str) -> Result<(String, i64)> {
     Ok((rev, epoch_from_iso(date)?))
 }
 
+/// get a text resource
+pub fn raw(url: &str) -> Result<String> {
+    let mut resp = agent()
+        .get(url)
+        .header("User-Agent", "tack")
+        .call()
+        .with_context(|| format!("GET {url}"))?;
+    let status = resp.status();
+    if status != 200 {
+        bail!("GET {url}: {status}");
+    }
+    let mut body = String::new();
+    resp.body_mut()
+        .as_reader()
+        .read_to_string(&mut body)
+        .with_context(|| format!("read body of {url}"))?;
+    Ok(body)
+}
+
 fn download_github_tarball(owner: &str, repo: &str, rev: &str, into: &Path) -> Result<PathBuf> {
     let url = format!("https://codeload.github.com/{owner}/{repo}/tar.gz/{rev}");
     let mut resp = agent()

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -20,7 +20,12 @@ pub fn load(path: &Path) -> Result<Lock> {
         return Ok(Lock::new());
     }
     let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-    serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))
+    parse(&raw).with_context(|| format!("parse {}", path.display()))
+}
+
+/// parse pins.lock.json from an in-memory string
+pub fn parse(raw: &str) -> Result<Lock> {
+    serde_json::from_str(raw).context("parse pins.lock.json")
 }
 
 pub fn save(path: &Path, lock: &Lock) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ fn run() -> anyhow::Result<()> {
         },
         Command::Rm { name } => commands::rm(&name),
         Command::Alias { name, template, rm } => commands::alias(&name, template.as_deref(), rm),
-        Command::Dedup { deep } => commands::dedup(deep),
+        Command::Dedup => commands::dedup(),
         Command::Help => {
             commands::help();
             Ok(())

--- a/src/pins.rs
+++ b/src/pins.rs
@@ -26,7 +26,7 @@ pub enum PinType {
 }
 
 impl PinType {
-    pub fn as_str(self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::Flake => "flake",
             Self::Fetch => "fetch",
@@ -34,8 +34,8 @@ impl PinType {
         }
     }
 
-    fn parse(s: &str) -> Result<Self> {
-        match s {
+    fn parse(str: &str) -> Result<Self> {
+        match str {
             "flake" => Ok(Self::Flake),
             "fetch" => Ok(Self::Fetch),
             "fixed" => Ok(Self::Fixed),
@@ -51,15 +51,15 @@ pub enum Unpack {
 }
 
 impl Unpack {
-    pub fn as_str(self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::Tarball => "tarball",
             Self::File => "file",
         }
     }
 
-    fn parse(s: &str) -> Result<Self> {
-        match s {
+    fn parse(str: &str) -> Result<Self> {
+        match str {
             "tarball" => Ok(Self::Tarball),
             "file" => Ok(Self::File),
             other => bail!("unknown unpack '{other}' (expected tarball|file)"),
@@ -68,13 +68,13 @@ impl Unpack {
 
     /// guess from a URL extension; tarball-family wins, otherwise file
     pub fn detect(url: &str) -> Self {
-        let path = url.split('?').next().unwrap_or(url);
-        let path = path.split('#').next().unwrap_or(path);
+        let no_query = url.split('?').next().unwrap_or(url);
+        let path = no_query.split('#').next().unwrap_or(no_query);
         let lower = path.to_ascii_lowercase();
         let tarballish = [
             ".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz", ".tbz2", ".tar.xz", ".txz",
         ];
-        if tarballish.iter().any(|s| lower.ends_with(s)) {
+        if tarballish.iter().any(|ending| lower.ends_with(ending)) {
             Self::Tarball
         } else {
             Self::File
@@ -133,7 +133,7 @@ pub fn inputs(doc: &DocumentMut) -> Result<Vec<Input>> {
             .with_context(|| format!("input '{name}' has no url"))?;
         // `type` is canonical; legacy `flake = false` reads as `fetch`
         let pin_type = match table.get("type").and_then(Item::as_str) {
-            Some(s) => PinType::parse(s).with_context(|| format!("input '{name}'"))?,
+            Some(typ) => PinType::parse(typ).with_context(|| format!("input '{name}'"))?,
             None => {
                 match table.get("flake").and_then(Item::as_bool) {
                     Some(false) => PinType::Fetch,
@@ -144,7 +144,7 @@ pub fn inputs(doc: &DocumentMut) -> Result<Vec<Input>> {
         let unpack = table
             .get("unpack")
             .and_then(Item::as_str)
-            .map(|s| Unpack::parse(s).with_context(|| format!("input '{name}'")))
+            .map(|unpack| Unpack::parse(unpack).with_context(|| format!("input '{name}'")))
             .transpose()?;
         if pin_type != PinType::Fixed && unpack.is_some() {
             bail!("input '{name}': `unpack` is only valid for type = \"fixed\"");
@@ -169,34 +169,33 @@ pub fn has_input(doc: &DocumentMut, name: &str) -> bool {
         .is_some_and(|tbl| tbl.contains_key(name))
 }
 
-pub fn add_input(
-    doc: &mut DocumentMut,
-    name: &str,
-    url: &str,
-    pin_type: PinType,
-    unpack: Option<Unpack>,
-    dir: Option<&str>,
-    submodules: bool,
-    follows: &[(String, String)],
-) {
+pub struct AddInputOpts<'a> {
+    pub pin_type:   PinType,
+    pub unpack:     Option<Unpack>,
+    pub dir:        Option<&'a str>,
+    pub submodules: bool,
+    pub follows:    &'a [(String, String)],
+}
+
+pub fn add_input(doc: &mut DocumentMut, name: &str, url: &str, opts: &AddInputOpts<'_>) {
     let mut entry = Table::new();
     entry.set_implicit(false);
     entry["url"] = value(url);
-    if pin_type != PinType::Flake {
-        entry["type"] = value(pin_type.as_str());
+    if opts.pin_type != PinType::Flake {
+        entry["type"] = value(opts.pin_type.as_str());
     }
-    if let Some(u) = unpack {
-        entry["unpack"] = value(u.as_str());
+    if let Some(unpak) = opts.unpack {
+        entry["unpack"] = value(unpak.as_str());
     }
-    if let Some(subdir) = dir {
+    if let Some(subdir) = opts.dir {
         entry["dir"] = value(subdir);
     }
-    if submodules {
+    if opts.submodules {
         entry["submodules"] = value(true);
     }
-    if !follows.is_empty() {
+    if !opts.follows.is_empty() {
         let mut follows_tbl = Table::new();
-        for &(ref child, ref parent) in follows {
+        for &(ref child, ref parent) in opts.follows {
             follows_tbl[child] = value(parent.as_str());
         }
         entry["follows"] = Item::Table(follows_tbl);

--- a/src/pins.rs
+++ b/src/pins.rs
@@ -95,8 +95,12 @@ pub fn load(path: &Path) -> Result<DocumentMut> {
         bail!("no pins.toml at {} (run `tack init`)", path.display());
     }
     let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-    raw.parse()
-        .with_context(|| format!("parse {}", path.display()))
+    parse_doc(&raw).with_context(|| format!("parse {}", path.display()))
+}
+
+/// parse pins.toml from an in-memory string
+pub fn parse_doc(raw: &str) -> Result<DocumentMut> {
+    raw.parse().context("parse pins.toml")
 }
 
 pub fn save(path: &Path, doc: &DocumentMut) -> Result<()> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -133,22 +133,21 @@ fn draw(names: &[String], states: &[PinStatus], frame: usize, drawn: bool) {
 }
 
 fn glyph(st: &PinStatus, frame: usize) -> String {
-    let (color, ch) = match st {
-        PinStatus::Pending => (2, '·'),
-        PinStatus::Fetching => (34, FRAMES[frame % FRAMES.len()]),
-        PinStatus::NoChange => (33, '-'),
-        PinStatus::Updated { .. } => (32, '✓'),
+    let (color, ch) = match *st {
+        PinStatus::Fetching => (34_i32, FRAMES[frame % FRAMES.len()]),
+        PinStatus::NoChange => (33_i32, '-'),
+        PinStatus::Updated { .. } => (32_i32, '\u{2713}'), // ✓
         PinStatus::Drift { accepted: true, .. } | PinStatus::FixedDrift { accepted: true, .. } => {
-            (33, '~')
+            (33_i32, '~')
         },
         PinStatus::Drift {
             accepted: false, ..
         }
         | PinStatus::FixedDrift {
             accepted: false, ..
-        } => (31, '!'),
-        PinStatus::Skipped(_) => (2, '·'),
-        PinStatus::Failed(_) => (31, '✗'),
+        } => (31_i32, '!'),
+        PinStatus::Pending | PinStatus::Skipped(_) => (2_i32, '\u{b7}'), // ·
+        PinStatus::Failed(_) => (31_i32, '\u{2717}'),                    // ✗
     };
     format!("\x1b[{color}m{ch}\x1b[0m")
 }
@@ -186,7 +185,7 @@ fn suffix(st: &PinStatus) -> String {
         },
         PinStatus::Skipped(ref note) => format!("  {note}"),
         PinStatus::Failed(ref msg) => format!("  {msg}"),
-        _ => String::new(),
+        PinStatus::Pending | PinStatus::Fetching | PinStatus::NoChange => String::new(),
     }
 }
 
@@ -231,6 +230,6 @@ fn plain_line(name: &str, st: &PinStatus) -> Option<String> {
         },
         PinStatus::Skipped(ref note) => Some(format!("{name}: {note}")),
         PinStatus::Failed(ref msg) => Some(format!("{name}: FAILED: {msg}")),
-        _ => None,
+        PinStatus::Pending | PinStatus::Fetching => None,
     }
 }


### PR DESCRIPTION
this pr fixes clippy lints that regressed recently, and enforces a clippy check to pass in the devshell (and subsequently ci). also, it speeds up `dedup` by using rest apis for forges that support them when looking up tack files. cloning is always done as a fallback, but this speeds the command up for me 6-7x. as a result, i've also made `--deep` the default behavior now.

lastly, it also supports more architectures, such as powerpc64.