### PR TITLE
source, fetch: clean up forge hosting

### DIFF
--- a/.tack/default.nix
+++ b/.tack/default.nix
@@ -56,14 +56,28 @@ let
           acc
       ) { } (attrNames all_follow_raw);
 
-      # a path node's stored path is absolute, or relative to this resolver dir
+      # a path node's stored path is absolute, or relative to this resolver dir.
+      # forgejo/gitea have no native fetchTree type, so they fetch over git
       fetchPin =
         name:
         let
           node = lock.${name};
+          nodeType = node.type or "";
         in
-        if (node.type or "") == "path" && substring 0 1 node.path != "/" then
+        if nodeType == "path" && substring 0 1 node.path != "/" then
           fetchTree (node // { path = ./. + ("/" + node.path); })
+        else if nodeType == "forge" then
+          fetchTree (
+            {
+              type = "git";
+              url = "https://${node.host}/${node.owner}/${node.repo}.git";
+            }
+            // intersectAttrs {
+              rev = null;
+              narHash = null;
+              lastModified = null;
+            } node
+          )
         else
           fetchTree node;
 

--- a/src/fetch/compare_planner.rs
+++ b/src/fetch/compare_planner.rs
@@ -304,6 +304,18 @@ impl CompareSource {
                     repo:  repo.clone(),
                 })
             },
+            Source::Forge {
+                ref host,
+                ref owner,
+                ref repo,
+                ..
+            } => {
+                Some(Self::ForgejoLike {
+                    host:  host.clone(),
+                    owner: owner.clone(),
+                    repo:  repo.clone(),
+                })
+            },
             Source::Git { .. } => {
                 let target = source.git_target()?;
                 Some(Self::Git {
@@ -332,6 +344,17 @@ impl CompareSource {
                 ref repo,
             } => {
                 Some(Self::Gitlab {
+                    host:  host.clone(),
+                    owner: owner.clone(),
+                    repo:  repo.clone(),
+                })
+            },
+            SourceId::Forge {
+                ref host,
+                ref owner,
+                ref repo,
+            } => {
+                Some(Self::ForgejoLike {
                     host:  host.clone(),
                     owner: owner.clone(),
                     repo:  repo.clone(),

--- a/src/fetch/compare_planner.rs
+++ b/src/fetch/compare_planner.rs
@@ -35,7 +35,7 @@ use crate::{
     lock::LockedNode,
     source::{
         Source,
-        gitlab as source_gitlab,
+        clone_url,
         id::SourceId,
     },
 };
@@ -52,8 +52,9 @@ pub enum CompareSource {
         owner: String,
         repo:  String,
     },
+    /// forgejo and gitea share the whole `/api/v1` surface, so the compare
+    /// path treats them identically and carries no kind
     ForgejoLike {
-        kind:  ForgejoLikeKind,
         host:  String,
         owner: String,
         repo:  String,
@@ -61,12 +62,6 @@ pub enum CompareSource {
     Git {
         url: String,
     },
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum ForgejoLikeKind {
-    Forgejo,
-    Gitea,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -358,7 +353,6 @@ impl CompareSource {
             },
             ForgeKind::Forgejo | ForgeKind::Gitea => {
                 Some(Self::ForgejoLike {
-                    kind:  forgejo_like_kind(repo.kind)?,
                     host:  repo.host,
                     owner: repo.owner,
                     repo:  repo.repo,
@@ -379,13 +373,12 @@ impl CompareSource {
                 ref host,
                 ref owner,
                 ref repo,
-            } => source_gitlab::clone_url(host, owner, repo),
-            Self::ForgejoLike {
+            }
+            | Self::ForgejoLike {
                 ref host,
                 ref owner,
                 ref repo,
-                ..
-            } => format!("https://{host}/{owner}/{repo}.git"),
+            } => clone_url(host, owner, repo),
             Self::Git { ref url } => url.clone(),
         }
     }
@@ -412,11 +405,11 @@ fn compare_api(job: &CompareJob) -> FetchResult<Option<CompareStatus>> {
             ref repo,
         } => gitlab::compare_status(host, owner, repo, &job.base, &job.head),
         CompareSource::ForgejoLike {
-            kind,
             ref host,
             ref owner,
             ref repo,
-        } => forge::compare_status(kind.into(), host, owner, repo, &job.base, &job.head),
+            // forgejo and gitea answer the same api, so the kind is a formality
+        } => forge::compare_status(ForgeKind::Forgejo, host, owner, repo, &job.base, &job.head),
         CompareSource::Git { ref url } => compare_detected_git_url(url, &job.base, &job.head),
     }
 }
@@ -460,14 +453,6 @@ fn compare_detected_git_url(
     })
 }
 
-const fn forgejo_like_kind(kind: ForgeKind) -> Option<ForgejoLikeKind> {
-    match kind {
-        ForgeKind::Forgejo => Some(ForgejoLikeKind::Forgejo),
-        ForgeKind::Gitea => Some(ForgejoLikeKind::Gitea),
-        ForgeKind::Gitlab | ForgeKind::Cgit | ForgeKind::Unknown => None,
-    }
-}
-
 fn fallback_dag(job: &CompareJob, api_error: Option<FetchError>) -> CompareAttempt {
     match git::compare_status(&job.source.clone_url(), &job.base, &job.head) {
         Ok(Some(status)) => CompareAttempt::verified(status),
@@ -479,21 +464,11 @@ fn fallback_dag(job: &CompareJob, api_error: Option<FetchError>) -> CompareAttem
     }
 }
 
-impl From<ForgejoLikeKind> for ForgeKind {
-    fn from(kind: ForgejoLikeKind) -> Self {
-        match kind {
-            ForgejoLikeKind::Forgejo => Self::Forgejo,
-            ForgejoLikeKind::Gitea => Self::Gitea,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
         CompareJob,
         CompareSource,
-        ForgejoLikeKind,
     };
     use crate::{
         fetch::CompareStatus,
@@ -521,7 +496,6 @@ mod tests {
         let session = super::CompareSession::new();
         let attempt = session.compare(&CompareJob {
             source: CompareSource::ForgejoLike {
-                kind:  ForgejoLikeKind::Forgejo,
                 host:  "git.example.com".to_owned(),
                 owner: "o".to_owned(),
                 repo:  "r".to_owned(),

--- a/src/fetch/forge.rs
+++ b/src/fetch/forge.rs
@@ -3,18 +3,31 @@
 use std::{
     borrow::Cow,
     collections::HashMap,
+    fs,
     io::Read as _,
     panic,
+    path::PathBuf,
     sync::{
         Mutex,
         OnceLock,
         PoisonError,
     },
     thread,
-    time::Duration,
+    time::{
+        Duration,
+        SystemTime,
+        UNIX_EPOCH,
+    },
 };
 
-use serde::Deserialize;
+use etcetera::{
+    BaseStrategy as _,
+    choose_base_strategy,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
 use ureq::http::{
     HeaderMap,
     header::ACCEPT,
@@ -29,16 +42,19 @@ use super::{
         HttpClient,
     },
 };
-use crate::source::{
-    forgejo,
-    git_url,
+use crate::{
+    project::write_atomic,
+    source::{
+        forgejo,
+        git_url,
+    },
 };
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 const COMPARE_TIMEOUT: Duration = Duration::from_secs(5);
 const APPLICATION_JSON: &str = "application/json";
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ForgeKind {
     Gitlab,
     Forgejo,
@@ -191,6 +207,10 @@ fn compare_count(host: &str, owner: &str, repo: &str, base: &str, head: &str) ->
     Ok(parsed.total_commits)
 }
 
+const DETECTION_TTL_DAYS: u64 = 14;
+const DETECTION_TTL: Duration = Duration::from_secs(DETECTION_TTL_DAYS * 24 * 60 * 60);
+const DETECTION_FILE: &str = "forge-detection.json";
+
 fn detect_host(host: &str) -> ForgeKind {
     let cache = host_cache();
     {
@@ -204,14 +224,23 @@ fn detect_host(host: &str) -> ForgeKind {
         }
     }
 
-    let detected = probe_host(host);
-    if detected != ForgeKind::Unknown {
+    if let Some(detected) = disk_lookup(host) {
         cache
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .insert(host.to_owned(), detected);
+        return detected;
     }
-    detected
+
+    let probe = probe_host(host);
+    if probe.cacheable {
+        cache
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(host.to_owned(), probe.kind);
+        disk_store(host, probe.kind);
+    }
+    probe.kind
 }
 
 fn host_cache() -> &'static Mutex<HashMap<String, ForgeKind>> {
@@ -219,56 +248,127 @@ fn host_cache() -> &'static Mutex<HashMap<String, ForgeKind>> {
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn probe_host(host: &str) -> ForgeKind {
-    if probe_version(&format!("https://{host}/api/forgejo/v1/version")) {
-        return ForgeKind::Forgejo;
-    }
-    if probe_version(&format!("https://{host}/api/v1/version")) {
-        return ForgeKind::Gitea;
-    }
-    if probe_gitlab(host, "metadata") || probe_gitlab(host, "version") {
-        return ForgeKind::Gitlab;
-    }
-    if probe_cgit(host) {
-        return ForgeKind::Cgit;
-    }
-    ForgeKind::Unknown
+/// the result of probing a host: the detected kind plus whether it is safe to
+/// persist. forge kinds are always cacheable; `Unknown` only when every probe
+/// reached the host and it simply is not a forge — a transport blip leaves it
+/// uncacheable so a brief outage cannot pin a host as "not a forge" until TTL
+struct ProbeResult {
+    kind:      ForgeKind,
+    cacheable: bool,
 }
 
-fn probe_version(url: &str) -> bool {
-    json::<VersionResponse>(url, PROBE_TIMEOUT)
-        .ok()
-        .and_then(|version| version.version)
-        .is_some_and(|version| !version.is_empty())
+fn probe_host(host: &str) -> ProbeResult {
+    let mut reachable = true;
+    match probe_version(&format!("https://{host}/api/forgejo/v1/version")) {
+        ProbeHit::Matched => return ProbeResult::found(ForgeKind::Forgejo),
+        ProbeHit::Missing => {},
+        ProbeHit::Unreachable => reachable = false,
+    }
+    match probe_version(&format!("https://{host}/api/v1/version")) {
+        ProbeHit::Matched => return ProbeResult::found(ForgeKind::Gitea),
+        ProbeHit::Missing => {},
+        ProbeHit::Unreachable => reachable = false,
+    }
+    for endpoint in ["metadata", "version"] {
+        match probe_gitlab(host, endpoint) {
+            ProbeHit::Matched => return ProbeResult::found(ForgeKind::Gitlab),
+            ProbeHit::Missing => {},
+            ProbeHit::Unreachable => reachable = false,
+        }
+    }
+    match probe_cgit(host) {
+        ProbeHit::Matched => return ProbeResult::found(ForgeKind::Cgit),
+        ProbeHit::Missing => {},
+        ProbeHit::Unreachable => reachable = false,
+    }
+    ProbeResult::unknown(reachable)
 }
 
-fn probe_gitlab(host: &str, endpoint: &str) -> bool {
+impl ProbeResult {
+    const fn found(kind: ForgeKind) -> Self {
+        Self {
+            kind,
+            cacheable: true,
+        }
+    }
+
+    /// `Unknown` is only cacheable when every probe reached the host; a
+    /// transport blip leaves it uncacheable so it is re-probed next run
+    const fn unknown(reachable: bool) -> Self {
+        Self {
+            kind:      ForgeKind::Unknown,
+            cacheable: reachable,
+        }
+    }
+}
+
+/// a single probe's outcome: a positive match, a definitive miss (the host
+/// answered but is not this forge), or a transport failure (could not tell)
+enum ProbeHit {
+    Matched,
+    Missing,
+    Unreachable,
+}
+
+impl ProbeHit {
+    const fn from_match(matched: bool) -> Self {
+        if matched {
+            Self::Matched
+        } else {
+            Self::Missing
+        }
+    }
+}
+
+fn probe_version(url: &str) -> ProbeHit {
+    match json::<VersionResponse>(url, PROBE_TIMEOUT) {
+        Ok(version) => ProbeHit::from_match(version.version.is_some_and(|value| !value.is_empty())),
+        Err(err) if is_definitive(&err) => ProbeHit::Missing,
+        Err(_) => ProbeHit::Unreachable,
+    }
+}
+
+fn probe_gitlab(host: &str, endpoint: &str) -> ProbeHit {
     let url = format!("https://{host}/api/v4/{endpoint}");
-    let Ok(resp) = get_text(&url, PROBE_TIMEOUT, 1024) else {
-        return false;
+    let resp = match get_text(&url, PROBE_TIMEOUT, 1024) {
+        Ok(resp) => resp,
+        Err(err) if is_definitive(&err) => return ProbeHit::Missing,
+        Err(_) => return ProbeHit::Unreachable,
     };
     if has_gitlab_header(&resp.headers) {
-        return true;
+        return ProbeHit::Matched;
     }
-    resp.status == 200
-        && serde_json::from_str::<GitlabProbe>(&resp.body)
-            .ok()
-            .is_some_and(|probe| probe.version.is_some() || probe.revision.is_some())
+    ProbeHit::from_match(
+        resp.status == 200
+            && serde_json::from_str::<GitlabProbe>(&resp.body)
+                .ok()
+                .is_some_and(|probe| probe.version.is_some() || probe.revision.is_some()),
+    )
 }
 
-fn probe_cgit(host: &str) -> bool {
+fn probe_cgit(host: &str) -> ProbeHit {
     let url = format!("https://{host}/");
-    let Ok(resp) = get_text(&url, PROBE_TIMEOUT, 16 * 1024) else {
-        return false;
+    let resp = match get_text(&url, PROBE_TIMEOUT, 16 * 1024) {
+        Ok(resp) => resp,
+        Err(err) if is_definitive(&err) => return ProbeHit::Missing,
+        Err(_) => return ProbeHit::Unreachable,
     };
     if resp.status != 200 {
-        return false;
+        return ProbeHit::Missing;
     }
     let body = resp.body.to_ascii_lowercase();
-    body.contains("name='generator' content='cgit")
-        || body.contains("name=\"generator\" content=\"cgit")
-        || body.contains("<div id='cgit'")
-        || body.contains("<div id=\"cgit\"")
+    ProbeHit::from_match(
+        body.contains("name='generator' content='cgit")
+            || body.contains("name=\"generator\" content=\"cgit")
+            || body.contains("<div id='cgit'")
+            || body.contains("<div id=\"cgit\""),
+    )
+}
+
+/// whether an error means the host answered (so absence of the forge is
+/// definitive) rather than that the request never completed
+const fn is_definitive(err: &FetchError) -> bool {
+    !matches!(err, FetchError::Transport(_))
 }
 
 fn has_gitlab_header(headers: &HeaderMap) -> bool {
@@ -324,6 +424,60 @@ fn get_text(url: &str, timeout: Duration, limit: u64) -> FetchResult<ProbeRespon
     })
 }
 
+#[derive(Clone, Copy, Serialize, Deserialize)]
+struct DiskEntry {
+    kind:      ForgeKind,
+    probed_at: u64,
+}
+
+fn detection_cache_path() -> Option<PathBuf> {
+    let strategy = choose_base_strategy().ok()?;
+    Some(strategy.cache_dir().join("tack").join(DETECTION_FILE))
+}
+
+fn disk_lookup(host: &str) -> Option<ForgeKind> {
+    let path = detection_cache_path()?;
+    let contents = fs::read_to_string(&path).ok()?;
+    let entries = serde_json::from_str::<HashMap<String, DiskEntry>>(&contents).ok()?;
+    let entry = entries.get(host)?;
+    is_fresh(entry, now_unix()).then_some(entry.kind)
+}
+
+fn disk_store(host: &str, kind: ForgeKind) {
+    let Some(path) = detection_cache_path() else {
+        return;
+    };
+    let mut entries = fs::read_to_string(&path)
+        .ok()
+        .and_then(|contents| serde_json::from_str::<HashMap<String, DiskEntry>>(&contents).ok())
+        .unwrap_or_default();
+    entries.insert(host.to_owned(), DiskEntry {
+        kind,
+        probed_at: now_unix(),
+    });
+    let Ok(mut json) = serde_json::to_string_pretty(&entries) else {
+        return;
+    };
+    json.push('\n');
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = write_atomic(&path, &json);
+}
+
+/// an entry is usable while its probe timestamp sits within the TTL window; a
+/// future timestamp (clock skewed backwards since the write) still counts fresh
+fn is_fresh(entry: &DiskEntry, now: u64) -> bool {
+    now.checked_sub(entry.probed_at)
+        .is_none_or(|age| age <= DETECTION_TTL.as_secs())
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |elapsed| elapsed.as_secs())
+}
+
 fn percent_encode(value: &str) -> Cow<'_, str> {
     percent_encoding::percent_encode(value.as_bytes(), super::PERCENT_ENCODE_SET).into()
 }
@@ -353,4 +507,81 @@ struct ForgeCompare {
 #[derive(Deserialize)]
 struct ForgeCommitRef {
     sha: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::{
+        DETECTION_TTL,
+        DiskEntry,
+        FetchError,
+        ForgeKind,
+        ProbeResult,
+        is_definitive,
+        is_fresh,
+    };
+
+    fn entry(probed_at: u64) -> DiskEntry {
+        DiskEntry {
+            kind: ForgeKind::Gitea,
+            probed_at,
+        }
+    }
+
+    #[test]
+    fn freshness_tracks_the_ttl_window() {
+        let ttl = DETECTION_TTL.as_secs();
+        let now = 2_000_000_000;
+        assert!(is_fresh(&entry(now), now));
+        assert!(is_fresh(&entry(now - ttl), now));
+        assert!(!is_fresh(&entry(now - ttl - 1), now));
+        // a clock skewed backwards must not read as infinitely fresh
+        assert!(is_fresh(&entry(now + 5), now));
+    }
+
+    #[test]
+    fn forge_kinds_are_always_cacheable() {
+        assert!(ProbeResult::found(ForgeKind::Forgejo).cacheable);
+        assert!(ProbeResult::found(ForgeKind::Cgit).cacheable);
+    }
+
+    #[test]
+    fn unknown_caches_only_when_every_probe_reached_the_host() {
+        let definitive = ProbeResult::unknown(true);
+        assert_eq!(definitive.kind, ForgeKind::Unknown);
+        assert!(definitive.cacheable);
+
+        let inconclusive = ProbeResult::unknown(false);
+        assert_eq!(inconclusive.kind, ForgeKind::Unknown);
+        assert!(!inconclusive.cacheable);
+    }
+
+    #[test]
+    fn transport_errors_are_inconclusive_others_definitive() {
+        assert!(!is_definitive(&FetchError::Transport("dropped".to_owned())));
+        assert!(is_definitive(&FetchError::NotFound {
+            what: "x".to_owned(),
+        }));
+        assert!(is_definitive(&FetchError::Auth {
+            what: "x".to_owned(),
+        }));
+        assert!(is_definitive(&FetchError::Forge("bad json".to_owned())));
+    }
+
+    #[test]
+    fn disk_entries_round_trip_through_json() {
+        let mut entries = HashMap::new();
+        entries.insert("git.example.org".to_owned(), entry(42));
+        entries.insert("unknown.example".to_owned(), DiskEntry {
+            kind:      ForgeKind::Unknown,
+            probed_at: 7,
+        });
+        let json = serde_json::to_string(&entries).unwrap();
+        let parsed = serde_json::from_str::<HashMap<String, DiskEntry>>(&json).unwrap();
+        assert_eq!(parsed["git.example.org"].kind, ForgeKind::Gitea);
+        assert_eq!(parsed["git.example.org"].probed_at, 42);
+        assert_eq!(parsed["unknown.example"].kind, ForgeKind::Unknown);
+    }
 }

--- a/src/fetch/forge.rs
+++ b/src/fetch/forge.rs
@@ -29,7 +29,10 @@ use super::{
         HttpClient,
     },
 };
-use crate::source::git_url;
+use crate::source::{
+    forgejo,
+    git_url,
+};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 const COMPARE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -42,6 +45,15 @@ pub enum ForgeKind {
     Gitea,
     Cgit,
     Unknown,
+}
+
+impl From<forgejo::Kind> for ForgeKind {
+    fn from(kind: forgejo::Kind) -> Self {
+        match kind {
+            forgejo::Kind::Forgejo => Self::Forgejo,
+            forgejo::Kind::Gitea => Self::Gitea,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/fetch/resolve.rs
+++ b/src/fetch/resolve.rs
@@ -40,7 +40,7 @@ use crate::{
     pins::Unpack,
     source::{
         Source,
-        gitlab as source_gitlab,
+        clone_url,
     },
 };
 
@@ -151,7 +151,7 @@ pub fn fetch_locked_tree_into(node: &LockedNode, dir: &Path) -> Result<PathBuf> 
             ..
         } => {
             let resolved_rev = locked_rev.as_deref().context("gitlab node missing rev")?;
-            let url = source_gitlab::clone_url(host, owner, repo);
+            let url = clone_url(host, owner, repo);
             git::fetch_tree_rev_into(&url, resolved_rev, false, dir)
         },
         LockedNode::Fixed { .. } | LockedNode::Indirect { .. } | LockedNode::Path { .. } => {

--- a/src/fetch/resolve.rs
+++ b/src/fetch/resolve.rs
@@ -52,6 +52,24 @@ pub fn current_rev(source: &Source) -> Result<String> {
             ref reff,
             rev: ref pinned,
         } => github::current_rev(owner, repo, reff.as_deref(), pinned.as_deref()),
+        Source::Forge {
+            kind,
+            ref host,
+            ref owner,
+            ref repo,
+            ref reff,
+            rev: ref pinned,
+        } => {
+            if let Some(target_rev) = pinned.as_deref() {
+                return Ok(target_rev.to_owned());
+            }
+            if let Some(rev) = forge::resolve_ref(kind.into(), host, owner, repo, reff.as_deref())?
+            {
+                return Ok(rev);
+            }
+            let url = clone_url(host, owner, repo);
+            git::current_rev(&url, reff.as_deref(), None)
+        },
         Source::Git { .. } | Source::Gitlab { .. } => {
             let target = source
                 .git_target()
@@ -154,6 +172,17 @@ pub fn fetch_locked_tree_into(node: &LockedNode, dir: &Path) -> Result<PathBuf> 
             let url = clone_url(host, owner, repo);
             git::fetch_tree_rev_into(&url, resolved_rev, false, dir)
         },
+        LockedNode::Forge {
+            ref host,
+            ref owner,
+            ref repo,
+            rev: ref locked_rev,
+            ..
+        } => {
+            let resolved_rev = locked_rev.as_deref().context("forge node missing rev")?;
+            let url = clone_url(host, owner, repo);
+            git::fetch_tree_rev_into(&url, resolved_rev, false, dir)
+        },
         LockedNode::Fixed { .. } | LockedNode::Indirect { .. } | LockedNode::Path { .. } => {
             bail!("cannot inspect tree for lock type '{}'", node.kind())
         },
@@ -168,8 +197,8 @@ pub fn fetch_tree_into(source: &Source, submodules: bool, dir: &Path) -> Result<
             ref reff,
             rev: ref pinned,
         } => github::fetch_tree_into(owner, repo, reff.as_deref(), pinned.as_deref(), dir),
-        Source::Git { .. } | Source::Gitlab { .. } => {
-            reject_gitlab_submodules(source, submodules)?;
+        Source::Git { .. } | Source::Gitlab { .. } | Source::Forge { .. } => {
+            reject_first_class_submodules(source, submodules)?;
             let target = source
                 .git_target()
                 .context("git-backed source missing git target")?;
@@ -201,8 +230,8 @@ pub fn fetch_pin(source: &Source, submodules: bool) -> Result<(LockedNode, Strin
             ref reff,
             rev: ref pinned,
         } => github::fetch_pin(owner, repo, reff.as_deref(), pinned.clone()),
-        Source::Git { .. } | Source::Gitlab { .. } => {
-            reject_gitlab_submodules(source, submodules)?;
+        Source::Git { .. } | Source::Gitlab { .. } | Source::Forge { .. } => {
+            reject_first_class_submodules(source, submodules)?;
             let target = source
                 .git_target()
                 .context("git-backed source missing git target")?;
@@ -238,9 +267,12 @@ pub fn fetch_pin(source: &Source, submodules: bool) -> Result<(LockedNode, Strin
     }
 }
 
-fn reject_gitlab_submodules(source: &Source, submodules: bool) -> Result<()> {
-    if submodules && matches!(source, Source::Gitlab { .. }) {
-        bail!("gitlab sources do not support submodules; use a git+ URL for submodule pins");
+fn reject_first_class_submodules(source: &Source, submodules: bool) -> Result<()> {
+    if submodules && matches!(source, Source::Gitlab { .. } | Source::Forge { .. }) {
+        bail!(
+            "gitlab/forgejo/gitea sources do not support submodules; use a git+ URL for submodule \
+             pins"
+        );
     }
     Ok(())
 }
@@ -269,6 +301,23 @@ fn git_pin_from_checkout(
             ..
         } => {
             LockedNode::new_gitlab(
+                host,
+                owner,
+                repo,
+                rev.clone(),
+                checkout.nar_hash,
+                checkout.last_modified,
+            )
+        },
+        Source::Forge {
+            kind,
+            ref host,
+            ref owner,
+            ref repo,
+            ..
+        } => {
+            LockedNode::new_forge(
+                kind,
                 host,
                 owner,
                 repo,
@@ -335,7 +384,7 @@ mod tests {
         git,
         git_pin_from_checkout,
         parse_link_immutable,
-        reject_gitlab_submodules,
+        reject_first_class_submodules,
     };
     use crate::{
         lock::LockedNode,
@@ -457,11 +506,50 @@ mod tests {
     fn first_class_gitlab_sources_reject_submodules() {
         let source = "gitlab:Group/Repo/main".parse::<Source>().unwrap();
 
-        let err = reject_gitlab_submodules(&source, true).unwrap_err();
+        let err = reject_first_class_submodules(&source, true).unwrap_err();
 
-        assert!(
-            err.to_string()
-                .contains("gitlab sources do not support submodules")
+        assert!(err.to_string().contains("do not support submodules"));
+    }
+
+    #[test]
+    fn forge_source_checkout_locks_as_forge_node() {
+        let source = "forgejo:Group/Repo/main?host=git.example.com&rev=abc123"
+            .parse::<Source>()
+            .unwrap();
+        let (fetched, rev) = git_pin_from_checkout(
+            &source,
+            git::PinCheckout {
+                rev:           "abc123".to_owned(),
+                nar_hash:      "sha256-n".to_owned(),
+                last_modified: 1700,
+                refname:       "refs/heads/main".to_owned(),
+            },
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(rev, "abc123");
+        assert_eq!(
+            fetched,
+            node(json!({
+                "type": "forge",
+                "kind": "forgejo",
+                "host": "git.example.com",
+                "owner": "Group",
+                "repo": "Repo",
+                "rev": "abc123",
+                "narHash": "sha256-n",
+                "lastModified": 1_700_i64
+            }))
         );
+    }
+
+    #[test]
+    fn forge_sources_reject_submodules() {
+        let source = "gitea:Group/Repo/main?host=git.example.com"
+            .parse::<Source>()
+            .unwrap();
+        let err = reject_first_class_submodules(&source, true).unwrap_err();
+        assert!(err.to_string().contains("do not support submodules"));
     }
 }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -15,6 +15,7 @@ use serde::{
 use serde_json::Value;
 
 use crate::source::{
+    forgejo,
     gitlab,
     normalize_host,
 };
@@ -183,6 +184,22 @@ pub enum LockedNode {
         #[serde(flatten)]
         extra:         ExtraFields,
     },
+    #[serde(rename = "forge")]
+    Forge {
+        kind:          forgejo::Kind,
+        #[serde(deserialize_with = "deserialize_host")]
+        host:          String,
+        owner:         String,
+        repo:          String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        rev:           Option<String>,
+        #[serde(rename = "narHash", skip_serializing_if = "Option::is_none")]
+        nar_hash:      Option<String>,
+        #[serde(rename = "lastModified", skip_serializing_if = "Option::is_none")]
+        last_modified: Option<i64>,
+        #[serde(flatten)]
+        extra:         ExtraFields,
+    },
     #[serde(rename = "git")]
     Git {
         url:           String,
@@ -294,6 +311,36 @@ impl LockedNode {
         }
     }
 
+    pub fn new_forge<Host, Owner, Repo, Rev, NarHash>(
+        kind: forgejo::Kind,
+        host: Host,
+        owner: Owner,
+        repo: Repo,
+        rev: Rev,
+        nar_hash: NarHash,
+        last_modified: i64,
+    ) -> Self
+    where
+        Host: Into<String>,
+        Owner: Into<String>,
+        Repo: Into<String>,
+        Rev: Into<String>,
+        NarHash: Into<String>,
+    {
+        let raw_host = host.into();
+        let canonical_host = normalize_host(&raw_host);
+        Self::Forge {
+            kind,
+            host: canonical_host,
+            owner: owner.into(),
+            repo: repo.into(),
+            rev: Some(rev.into()),
+            nar_hash: Some(nar_hash.into()),
+            last_modified: Some(last_modified),
+            extra: BTreeMap::new(),
+        }
+    }
+
     pub fn new_git<Url, Ref, Rev, NarHash>(
         url: Url,
         reff: Ref,
@@ -360,6 +407,7 @@ impl LockedNode {
         match self {
             Self::Github { .. } => "github",
             Self::Gitlab { .. } => "gitlab",
+            Self::Forge { .. } => "forge",
             Self::Git { .. } => "git",
             Self::Tarball { .. } => "tarball",
             Self::Fixed { .. } => "fixed",
@@ -372,18 +420,20 @@ impl LockedNode {
         match self {
             Self::Tarball { url, .. } => Some(url),
             Self::Fixed { sha256, .. } => sha256.as_deref(),
-            Self::Github { rev, .. } | Self::Gitlab { rev, .. } | Self::Git { rev, .. } => {
-                rev.as_deref()
-            },
+            Self::Github { rev, .. }
+            | Self::Gitlab { rev, .. }
+            | Self::Forge { rev, .. }
+            | Self::Git { rev, .. } => rev.as_deref(),
             Self::Indirect { .. } | Self::Path { .. } => None,
         }
     }
 
     pub fn full_rev(&self) -> Option<&str> {
         match self {
-            Self::Github { rev, .. } | Self::Gitlab { rev, .. } | Self::Git { rev, .. } => {
-                rev.as_deref()
-            },
+            Self::Github { rev, .. }
+            | Self::Gitlab { rev, .. }
+            | Self::Forge { rev, .. }
+            | Self::Git { rev, .. } => rev.as_deref(),
             Self::Tarball { url, .. } => Some(url),
             Self::Fixed { url, sha256, .. } => url.as_deref().or(sha256.as_deref()),
             Self::Indirect { .. } | Self::Path { .. } => None,
@@ -395,6 +445,7 @@ impl LockedNode {
             Self::Fixed { sha256, .. } => sha256.as_deref(),
             Self::Github { nar_hash, .. }
             | Self::Gitlab { nar_hash, .. }
+            | Self::Forge { nar_hash, .. }
             | Self::Git { nar_hash, .. }
             | Self::Tarball { nar_hash, .. } => nar_hash.as_deref(),
             Self::Indirect { .. } | Self::Path { .. } => None,
@@ -405,6 +456,7 @@ impl LockedNode {
         let value = match self {
             Self::Github { last_modified, .. }
             | Self::Gitlab { last_modified, .. }
+            | Self::Forge { last_modified, .. }
             | Self::Git { last_modified, .. }
             | Self::Tarball { last_modified, .. } => *last_modified,
             Self::Fixed { .. } | Self::Indirect { .. } | Self::Path { .. } => None,
@@ -466,6 +518,7 @@ mod tests {
         LockFile,
         LockedNode,
     };
+    use crate::source::forgejo::Kind;
 
     fn node(value: Value) -> LockedNode {
         LockedNode::from_value(value).unwrap()
@@ -629,6 +682,51 @@ mod tests {
     }
 
     #[test]
+    fn forge_node_round_trips_kind_and_host() {
+        let parsed = node(json!({
+            "type": "forge",
+            "kind": "gitea",
+            "host": "Git.Example.Com:8443",
+            "owner": "o",
+            "repo": "r",
+            "rev": "abc",
+            "narHash": "sha256-n",
+            "lastModified": 1700_i64
+        }));
+        assert!(matches!(
+            parsed,
+            LockedNode::Forge {
+                kind: Kind::Gitea,
+                ref host,
+                ..
+            } if host == "git.example.com:8443"
+        ));
+
+        let serialized = serde_json::to_value(LockedNode::new_forge(
+            Kind::Forgejo,
+            "Git.Example.Com",
+            "o",
+            "r",
+            "rev",
+            "sha256-n",
+            10,
+        ))
+        .unwrap();
+        assert_eq!(
+            serialized.get("type").and_then(Value::as_str),
+            Some("forge")
+        );
+        assert_eq!(
+            serialized.get("kind").and_then(Value::as_str),
+            Some("forgejo")
+        );
+        assert_eq!(
+            serialized.get("host").and_then(Value::as_str),
+            Some("git.example.com")
+        );
+    }
+
+    #[test]
     fn gitlab_host_is_canonicalized_at_lock_boundary() {
         let parsed = node(json!({
             "type": "gitlab",
@@ -693,6 +791,7 @@ mod tests {
                 let repo = match *node {
                     LockedNode::Github { ref repo, .. } => Some(repo.to_owned()),
                     LockedNode::Gitlab { .. }
+                    | LockedNode::Forge { .. }
                     | LockedNode::Git { .. }
                     | LockedNode::Tarball { .. }
                     | LockedNode::Fixed { .. }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -14,7 +14,10 @@ use serde::{
 };
 use serde_json::Value;
 
-use crate::source::gitlab;
+use crate::source::{
+    gitlab,
+    normalize_host,
+};
 
 /// on-disk lock file keyed by input name
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -167,7 +170,7 @@ pub enum LockedNode {
         repo:          String,
         #[serde(
             default = "default_gitlab_host",
-            deserialize_with = "deserialize_gitlab_host",
+            deserialize_with = "deserialize_host",
             skip_serializing_if = "is_default_gitlab_host"
         )]
         host:          String,
@@ -279,7 +282,7 @@ impl LockedNode {
         NarHash: Into<String>,
     {
         let raw_host = host.into();
-        let canonical_host = gitlab::normalize_host(&raw_host);
+        let canonical_host = normalize_host(&raw_host);
         Self::Gitlab {
             host:          canonical_host,
             owner:         owner.into(),
@@ -426,11 +429,11 @@ where
     Ok(locked.and_then(|value| LockedNode::from_value(value).ok()))
 }
 
-fn deserialize_gitlab_host<'de, D>(deserializer: D) -> Result<String, D::Error>
+fn deserialize_host<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: Deserializer<'de>,
 {
-    String::deserialize(deserializer).map(|host| gitlab::normalize_host(&host))
+    String::deserialize(deserializer).map(|host| normalize_host(&host))
 }
 
 fn is_default_gitlab_host(host: &str) -> bool {

--- a/src/source/forge.rs
+++ b/src/source/forge.rs
@@ -37,6 +37,12 @@ static GITLAB_SCHEME: HostScheme = HostScheme {
     decoder: None,
 };
 
+static FORGEJO_SCHEME: HostScheme = HostScheme {
+    matches: |_| true,
+    build:   |base, rev, file| format!("{base}/raw/commit/{rev}/{file}"),
+    decoder: None,
+};
+
 static BITBUCKET_SCHEME: HostScheme = HostScheme {
     matches: |host| host == "bitbucket.org",
     build:   |base, rev, file| format!("{base}/raw/{rev}/{file}"),
@@ -99,6 +105,18 @@ impl Forge {
                     format!("https://{host}/{owner}/{repo}"),
                     true,
                     &GITLAB_SCHEME,
+                )
+            },
+            LockedNode::Forge {
+                ref host,
+                ref owner,
+                ref repo,
+                ..
+            } => {
+                (
+                    format!("https://{host}/{owner}/{repo}"),
+                    true,
+                    &FORGEJO_SCHEME,
                 )
             },
             LockedNode::Git { ref url, .. } => {

--- a/src/source/forgejo.rs
+++ b/src/source/forgejo.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: EUPL-1.2
+
+use std::fmt::{
+    self,
+    Display,
+};
+
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use super::{
+    decode_path_segment,
+    host,
+    parse_query_fields,
+    split_query_fragment,
+};
+
+/// forgejo and gitea share the same `/api/v1/` surface; this carries which one
+/// a pin declared so the fetch layer can skip host detection
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Kind {
+    Forgejo,
+    Gitea,
+}
+
+impl Kind {
+    pub const fn scheme(self) -> &'static str {
+        match self {
+            Self::Forgejo => "forgejo",
+            Self::Gitea => "gitea",
+        }
+    }
+
+    pub fn from_scheme(scheme: &str) -> Option<Self> {
+        match scheme {
+            "forgejo" => Some(Self::Forgejo),
+            "gitea" => Some(Self::Gitea),
+            _ => None,
+        }
+    }
+}
+
+impl Display for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.scheme())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FlakeRef {
+    pub kind:  Kind,
+    pub host:  String,
+    pub owner: String,
+    pub repo:  String,
+    pub reff:  Option<String>,
+    pub rev:   Option<String>,
+}
+
+/// parse a `forgejo:`/`gitea:` body. host is mandatory: these forges self-host
+/// on arbitrary domains with no canonical home
+pub fn parse_flake_url(kind: Kind, body: &str) -> Option<FlakeRef> {
+    let (path, query) = split_query_fragment(body);
+    let mut segs = path.split('/');
+    let owner = decode_path_segment(segs.next().filter(|segment| !segment.is_empty())?);
+    let repo = decode_path_segment(segs.next().filter(|segment| !segment.is_empty())?);
+    let query_fields = parse_query_fields(query);
+    let host = host::normalized(query_fields.host?);
+    let path_ref = segs.collect::<Vec<_>>().join("/");
+    let reff = query_fields
+        .reff
+        .map(ToOwned::to_owned)
+        .or_else(|| (!path_ref.is_empty()).then_some(path_ref));
+    Some(FlakeRef {
+        kind,
+        host,
+        owner,
+        repo,
+        reff,
+        rev: query_fields.rev.map(ToOwned::to_owned),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Kind,
+        parse_flake_url,
+    };
+
+    #[test]
+    fn parses_forgejo_flake_url() {
+        let parsed =
+            parse_flake_url(Kind::Forgejo, "owner/repo/main?host=Git.Example.Com:8443").unwrap();
+
+        assert_eq!(parsed.kind, Kind::Forgejo);
+        assert_eq!(parsed.host, "git.example.com:8443");
+        assert_eq!(parsed.owner, "owner");
+        assert_eq!(parsed.repo, "repo");
+        assert_eq!(parsed.reff.as_deref(), Some("main"));
+        assert_eq!(parsed.rev, None);
+    }
+
+    #[test]
+    fn gitea_alias_parses_with_kind() {
+        let parsed = parse_flake_url(Kind::Gitea, "o/r?host=git.example.com&rev=abc").unwrap();
+
+        assert_eq!(parsed.kind, Kind::Gitea);
+        assert_eq!(parsed.host, "git.example.com");
+        assert_eq!(parsed.rev.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn missing_host_is_rejected() {
+        assert!(parse_flake_url(Kind::Forgejo, "o/r/main").is_none());
+    }
+
+    #[test]
+    fn decodes_nested_group_owner() {
+        let parsed =
+            parse_flake_url(Kind::Forgejo, "group%2Fsub/repo?host=git.example.com").unwrap();
+        assert_eq!(parsed.owner, "group/sub");
+    }
+}

--- a/src/source/git_url.rs
+++ b/src/source/git_url.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 use super::{
+    decode_path_segment,
     host,
     strip_query_fragment,
 };
@@ -95,12 +96,6 @@ fn strip_port(host: &str) -> &str {
         return host;
     }
     name
-}
-
-fn decode_path_segment(value: &str) -> String {
-    percent_encoding::percent_decode_str(value)
-        .decode_utf8()
-        .map_or_else(|_| value.to_owned(), Into::into)
 }
 
 #[cfg(test)]

--- a/src/source/gitlab.rs
+++ b/src/source/gitlab.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 use super::{
+    decode_path_segment,
     host,
     parse_query_fields,
     split_query_fragment,
@@ -69,12 +70,8 @@ pub fn parse_git_url(url: &str) -> Option<RepoRef> {
     parse_git_parts(host, raw_path, HostPortPolicy::Default(default_port))
 }
 
-pub fn normalize_host(host: &str) -> String {
-    host::normalized(host)
-}
-
 pub fn is_default_host(host: &str) -> bool {
-    normalize_host(host) == DEFAULT_HOST
+    host::normalized(host) == DEFAULT_HOST
 }
 
 #[derive(Clone, Copy)]
@@ -114,10 +111,6 @@ fn parse_git_parts(
     })
 }
 
-pub fn clone_url(host: &str, owner: &str, repo: &str) -> String {
-    format!("https://{host}/{owner}/{repo}.git")
-}
-
 fn parse_scp_like(url: &str) -> Option<(&str, &str)> {
     if url.contains("://") {
         return None;
@@ -151,17 +144,10 @@ fn strip_port(host: &str) -> &str {
     name
 }
 
-fn decode_path_segment(value: &str) -> String {
-    percent_encoding::percent_decode_str(value)
-        .decode_utf8()
-        .map_or_else(|_| value.to_owned(), Into::into)
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
         DEFAULT_HOST,
-        clone_url,
         parse_flake_url,
         parse_git_url,
     };
@@ -240,13 +226,5 @@ mod tests {
         assert_eq!(parsed.host, "gitlab.example.com");
         assert_eq!(parsed.owner, "group/sub");
         assert_eq!(parsed.repo, "repo");
-    }
-
-    #[test]
-    fn builds_clone_url() {
-        assert_eq!(
-            clone_url("gitlab.com:8443", "NixOS", "nixpkgs"),
-            "https://gitlab.com:8443/NixOS/nixpkgs.git"
-        );
     }
 }

--- a/src/source/id.rs
+++ b/src/source/id.rs
@@ -30,6 +30,13 @@ pub enum SourceId {
         owner: String,
         repo:  String,
     },
+    /// forgejo and gitea collapse to one identity: same clone url, same tree,
+    /// and the api treats them alike, so the declared kind is not part of it
+    Forge {
+        host:  String,
+        owner: String,
+        repo:  String,
+    },
     /// git+url, query string stripped
     Git {
         url: String,
@@ -64,6 +71,12 @@ impl SourceId {
                 ref repo,
                 ..
             } => Self::gitlab(host, owner, repo),
+            Source::Forge {
+                ref host,
+                ref owner,
+                ref repo,
+                ..
+            } => Self::forge(host, owner, repo),
             Source::Git { ref url, .. } => {
                 if let Some(repo) = gitlab::parse_git_url(url) {
                     return Self::gitlab(&repo.host, &repo.owner, &repo.repo);
@@ -98,6 +111,12 @@ impl SourceId {
                 ref repo,
                 ..
             } => Some(Self::gitlab(host, owner, repo)),
+            LockedNode::Forge {
+                ref host,
+                ref owner,
+                ref repo,
+                ..
+            } => Some(Self::forge(host, owner, repo)),
             LockedNode::Git { ref url, .. } => {
                 let cut = strip_query_fragment(url);
                 if let Some(repo) = gitlab::parse_git_url(cut) {
@@ -141,9 +160,19 @@ impl SourceId {
         }
     }
 
+    fn forge(host: &str, owner: &str, repo: &str) -> Self {
+        Self::Forge {
+            host:  host::normalized(host),
+            owner: owner.to_lowercase(),
+            repo:  repo.to_lowercase(),
+        }
+    }
+
     pub fn repo_name(&self) -> Option<&str> {
         match *self {
-            Self::Github { ref repo, .. } | Self::Gitlab { ref repo, .. } => Some(repo),
+            Self::Github { ref repo, .. }
+            | Self::Gitlab { ref repo, .. }
+            | Self::Forge { ref repo, .. } => Some(repo),
             Self::Git { .. } | Self::Tarball { .. } | Self::Indirect { .. } | Self::Path { .. } => {
                 None
             },
@@ -163,6 +192,11 @@ impl Display for SourceId {
                 ref owner,
                 ref repo,
             } => write!(f, "gitlab:{host}/{owner}/{repo}"),
+            Self::Forge {
+                ref host,
+                ref owner,
+                ref repo,
+            } => write!(f, "forge:{host}/{owner}/{repo}"),
             Self::Git { ref url } => write!(f, "git+{url}"),
             Self::Tarball { ref url } => write!(f, "tarball:{url}"),
             Self::Indirect { ref id } => write!(f, "indirect:{id}"),
@@ -432,6 +466,48 @@ mod tests {
             "gitlab:git.example.com/nixos/nixpkgs"
         );
         assert_ne!(default_host, self_hosted);
+    }
+
+    #[test]
+    fn forge_url_and_node_agree() {
+        let from_url = SourceId::from_url("forgejo:NixOS/Nixpkgs?host=Git.Example.Com").unwrap();
+        let from_node = SourceId::from_locked(&node(json!({
+            "type": "forge",
+            "kind": "forgejo",
+            "host": "git.example.com",
+            "owner": "nixos",
+            "repo": "nixpkgs"
+        })))
+        .unwrap();
+
+        assert_eq!(from_url, from_node);
+        assert_eq!(from_url.to_string(), "forge:git.example.com/nixos/nixpkgs");
+    }
+
+    #[test]
+    fn gitea_alias_shares_forge_identity() {
+        let forgejo = SourceId::from_url("forgejo:o/r?host=git.example.com").unwrap();
+        let gitea = SourceId::from_url("gitea:o/r?host=git.example.com").unwrap();
+
+        // the declared kind is cosmetic: both resolve and compare identically
+        assert_eq!(gitea.to_string(), "forge:git.example.com/o/r");
+        assert_eq!(forgejo, gitea);
+    }
+
+    #[test]
+    fn forge_identity_preserves_non_default_port() {
+        let from_url = SourceId::from_url("gitea:o/r?host=Git.Example.Com:8443").unwrap();
+        let from_node = SourceId::from_locked(&node(json!({
+            "type": "forge",
+            "kind": "gitea",
+            "host": "Git.Example.Com:8443",
+            "owner": "o",
+            "repo": "r"
+        })))
+        .unwrap();
+
+        assert_eq!(from_url, from_node);
+        assert_eq!(from_url.to_string(), "forge:git.example.com:8443/o/r");
     }
 
     #[test]

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -83,7 +83,7 @@ impl Source {
                 ref rev,
             } => {
                 Some(GitTarget {
-                    url:  Cow::Owned(gitlab::clone_url(host, owner, repo)),
+                    url:  Cow::Owned(clone_url(host, owner, repo)),
                     reff: reff.as_deref(),
                     rev:  rev.as_deref(),
                 })
@@ -297,6 +297,22 @@ fn parse_query_fields(query: Option<&str>) -> QueryFields<'_> {
     fields
 }
 
+/// https clone url for a host/owner/repo on any git forge
+pub fn clone_url(host: &str, owner: &str, repo: &str) -> String {
+    format!("https://{host}/{owner}/{repo}.git")
+}
+
+/// canonicalize a forge host (lowercase, drop the default https port)
+pub fn normalize_host(host: &str) -> String {
+    host::normalized(host)
+}
+
+fn decode_path_segment(value: &str) -> String {
+    percent_encoding::percent_decode_str(value)
+        .decode_utf8()
+        .map_or_else(|_| value.to_owned(), Into::into)
+}
+
 #[cfg(test)]
 #[expect(clippy::panic, reason = "panic is the test-failure coping mechanism")]
 mod tests {
@@ -304,8 +320,17 @@ mod tests {
 
     use super::{
         Source,
+        clone_url,
         localize_path_url_with_warning,
     };
+
+    #[test]
+    fn builds_clone_url() {
+        assert_eq!(
+            clone_url("gitlab.com:8443", "NixOS", "nixpkgs"),
+            "https://gitlab.com:8443/NixOS/nixpkgs.git"
+        );
+    }
 
     #[test]
     fn path_url_is_a_path_source() {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 pub mod forge;
+pub mod forgejo;
 pub mod git_url;
 pub mod id;
 
@@ -44,6 +45,14 @@ pub enum Source {
         reff:  Option<String>,
         rev:   Option<String>,
     },
+    Forge {
+        kind:  forgejo::Kind,
+        host:  String,
+        owner: String,
+        repo:  String,
+        reff:  Option<String>,
+        rev:   Option<String>,
+    },
     Tarball {
         url: String,
     },
@@ -75,12 +84,22 @@ impl Source {
                     rev:  rev.as_deref(),
                 })
             },
+            // identical clone url for the tree fetch + dag fallback; rev
+            // resolution and ahead/behind still dispatch per-forge elsewhere
             Self::Gitlab {
                 ref host,
                 ref owner,
                 ref repo,
                 ref reff,
                 ref rev,
+            }
+            | Self::Forge {
+                ref host,
+                ref owner,
+                ref repo,
+                ref reff,
+                ref rev,
+                ..
             } => {
                 Some(GitTarget {
                     url:  Cow::Owned(clone_url(host, owner, repo)),
@@ -120,6 +139,21 @@ impl FromStr for Source {
                 bail!("malformed gitlab url: {expanded}");
             };
             return Ok(Self::Gitlab {
+                host:  parsed.host,
+                owner: parsed.owner,
+                repo:  parsed.repo,
+                reff:  parsed.reff,
+                rev:   parsed.rev,
+            });
+        }
+        if let Some((scheme, body)) = expanded.split_once(':')
+            && let Some(kind) = forgejo::Kind::from_scheme(scheme)
+        {
+            let Some(parsed) = forgejo::parse_flake_url(kind, body) else {
+                bail!("malformed {scheme} url (host= is required): {expanded}");
+            };
+            return Ok(Self::Forge {
+                kind:  parsed.kind,
                 host:  parsed.host,
                 owner: parsed.owner,
                 repo:  parsed.repo,
@@ -339,6 +373,7 @@ mod tests {
             Source::Github { .. }
             | Source::Git { .. }
             | Source::Gitlab { .. }
+            | Source::Forge { .. }
             | Source::Tarball { .. } => panic!("expected path source"),
         }
     }
@@ -380,6 +415,7 @@ mod tests {
             },
             Source::Github { .. }
             | Source::Gitlab { .. }
+            | Source::Forge { .. }
             | Source::Tarball { .. }
             | Source::Path { .. } => {
                 panic!("expected git target")
@@ -395,6 +431,7 @@ mod tests {
             },
             Source::Github { .. }
             | Source::Gitlab { .. }
+            | Source::Forge { .. }
             | Source::Tarball { .. }
             | Source::Path { .. } => {
                 panic!("expected git target")
@@ -415,6 +452,7 @@ mod tests {
             },
             Source::Github { .. }
             | Source::Gitlab { .. }
+            | Source::Forge { .. }
             | Source::Tarball { .. }
             | Source::Path { .. } => {
                 panic!("expected git target")
@@ -443,11 +481,76 @@ mod tests {
             },
             Source::Github { .. }
             | Source::Git { .. }
+            | Source::Forge { .. }
             | Source::Tarball { .. }
             | Source::Path { .. } => {
                 panic!("expected gitlab target")
             },
         }
+    }
+
+    #[test]
+    fn forgejo_url_is_first_class_source() {
+        match "forgejo:owner/repo/main?host=Git.Example.Com&rev=abc123"
+            .parse::<Source>()
+            .unwrap()
+        {
+            Source::Forge {
+                kind,
+                host,
+                owner,
+                repo,
+                reff,
+                rev,
+            } => {
+                assert_eq!(kind, super::forgejo::Kind::Forgejo);
+                assert_eq!(host, "git.example.com");
+                assert_eq!(owner, "owner");
+                assert_eq!(repo, "repo");
+                assert_eq!(reff.as_deref(), Some("main"));
+                assert_eq!(rev.as_deref(), Some("abc123"));
+            },
+            Source::Github { .. }
+            | Source::Git { .. }
+            | Source::Gitlab { .. }
+            | Source::Tarball { .. }
+            | Source::Path { .. } => panic!("expected forge target"),
+        }
+    }
+
+    #[test]
+    fn gitea_alias_parses_as_forge_source() {
+        match "gitea:o/r?host=git.example.com".parse::<Source>().unwrap() {
+            Source::Forge { kind, host, .. } => {
+                assert_eq!(kind, super::forgejo::Kind::Gitea);
+                assert_eq!(host, "git.example.com");
+            },
+            Source::Github { .. }
+            | Source::Git { .. }
+            | Source::Gitlab { .. }
+            | Source::Tarball { .. }
+            | Source::Path { .. } => panic!("expected forge target"),
+        }
+    }
+
+    #[test]
+    fn forge_url_requires_host() {
+        let err = "forgejo:o/r/main".parse::<Source>().unwrap_err();
+        assert!(err.to_string().contains("host= is required"));
+    }
+
+    #[test]
+    fn forge_git_target_uses_clone_url() {
+        let forge = "forgejo:owner/repo/main?host=git.example.com&rev=abc123"
+            .parse::<Source>()
+            .unwrap();
+        let target = forge.git_target().unwrap();
+        assert_eq!(
+            target.url.as_ref(),
+            "https://git.example.com/owner/repo.git"
+        );
+        assert_eq!(target.reff, Some("main"));
+        assert_eq!(target.rev, Some("abc123"));
     }
 
     #[test]
@@ -481,6 +584,7 @@ mod tests {
             },
             Source::Git { .. }
             | Source::Gitlab { .. }
+            | Source::Forge { .. }
             | Source::Tarball { .. }
             | Source::Path { .. } => {
                 panic!("expected github target")
@@ -503,6 +607,7 @@ mod tests {
             Source::Github { .. }
             | Source::Git { .. }
             | Source::Gitlab { .. }
+            | Source::Forge { .. }
             | Source::Path { .. } => {
                 panic!("expected tarball target")
             },
@@ -515,6 +620,7 @@ mod tests {
             Source::Github { .. }
             | Source::Git { .. }
             | Source::Gitlab { .. }
+            | Source::Forge { .. }
             | Source::Path { .. } => {
                 panic!("expected tarball target")
             },


### PR DESCRIPTION
- persists forge type detection to prevent doing the same work frequently
- adds forgejo: and gitea: as url prefixes to directly specify forge type