### PR TITLE
test: fix failing test on darwin

### DIFF
--- a/src/fetch/git_http_tests.rs
+++ b/src/fetch/git_http_tests.rs
@@ -48,7 +48,7 @@ fn write_response(stream: &mut TcpStream, head: &str, body: &str) {
 
 #[test]
 fn unauthorized_request_resolves_credential_and_retries_with_authorization() {
-    let host = "127.0.0.2";
+    let host = "127.0.0.1";
     auth::seed_resolvable_credential(host, "atagen", "s3cr3t");
     let listener = TcpListener::bind((host, 0)).unwrap();
     let url = format!(


### PR DESCRIPTION
Use an address `127.0.0.1` instead of `127.0.0.2` in a test:
https://github.com/manic-systems/tack/blob/95ddc34601dcded62dc5d3cba27a5d102136f542/src/fetch/git_http_tests.rs#L49-L96

<details>
<summary>cargo test output before the fix</summary>

```rust
   Compiling tack-pins v1.0.0 (/Users/retr0/Projects/tack)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.01s
     Running unittests src/lib.rs (target/debug/deps/tack-54ab0dcda7b2a1fe)

running 30 tests
test commands::dedup::auto::tests::auto_dedup_prefers_branch_status_over_timestamp ... ok
test commands::dedup::compare::tests::comparator_prefers_top_level_pin_over_newer_transitive ... ok
test commands::dedup::auto::tests::restrict_to_seed_identity_drops_foreign_repositories ... ok
test fetch::auth::tests::credential_ladder_falls_back_only_for_credential_failures ... ok
test commands::dedup::follows::tests::apply_follows_syncs_rev_and_lm_to_target ... ok
test fetch::compare_planner::tests::dag_fallback_cause_surfaces_both_failures ... ok
test commands::dedup::compare::tests::compare_jobs_are_capped_before_network_work ... ok
test fetch::compare_planner::tests::identical_compare_job_is_verified_without_network ... ok
test commands::dedup::compare::tests::classify_prefers_branch_status_over_timestamps ... ok
test commands::dedup::scan::tests::scan_records_gitlab_locked_nodes ... ok
test commands::dedup::scan::tests::scan_reports_tack_lock_parse_failure_and_continues ... ok
test fetch::github::tests::parses_graphql_ref_compare_response ... ok
test fetch::resolve::tests::gitlab_git_url_checkout_stays_generic_git_lock ... ok
test fetch::auth::tests::access_tokens_scrape_follows_include_and_later_lines_win ... ok
test fetch::resolve::tests::tarball_with_rev_drops_last_modified ... ok
test fetch::resolve::tests::git_revision_read_trimmed_and_validated ... ok
test fetch::resolve::tests::path_pin_locks_absolute_targets_with_a_metadata_fingerprint ... ok
test lock::tests::extra_lock_fields_survive_node_roundtrip ... ok
test lock::tests::remove_and_insert_replace_unknown_nodes ... ok
test fetch::git_http::tests::unauthorized_request_resolves_credential_and_retries_with_authorization ... FAILED
test pins::tests::all_follows_array_form_implies_key_alias ... ok
test pins::tests::inputs_read_type_unpack_and_legacy_flake_from_each_entry ... ok
test source::id::tests::source_identity_normalizes_common_url_and_lock_forms ... ok
test source::id::tests::gitlab_identity_keeps_nested_groups_and_self_hosted_boundaries ... ok
test lock::tests::save_preserves_unknown_lock_nodes ... ok
test history::tests::undo_preserves_external_edits_as_redo_state ... ok
test history::tests::undo_then_redo_round_trips_state ... ok
test fetch::git::tests::pinned_rev_reachable_only_off_named_ref_is_found ... ok
test source::tests::localize_keeps_store_copied_path_urls_reachable ... ok
test fetch::git::dag::tests::compares_file_remote_topology ... ok

failures:

---- fetch::git_http::tests::unauthorized_request_resolves_credential_and_retries_with_authorization stdout ----

thread 'fetch::git_http::tests::unauthorized_request_resolves_credential_and_retries_with_authorization' (14687) panicked at src/fetch/git_http_tests.rs:53:49:
called `Result::unwrap()` on an `Err` value: Os { code: 49, kind: AddrNotAvailable, message: "Can't assign requested address" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    fetch::git_http::tests::unauthorized_request_resolves_credential_and_retries_with_authorization

test result: FAILED. 29 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

error: test failed, to rerun pass `--lib`
```
</details>

<details>
<summary>cargo test output after the fix</summary>

```rust
   Compiling tack-pins v1.0.0 (/Users/retr0/Projects/tack)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.31s
     Running unittests src/lib.rs (target/debug/deps/tack-54ab0dcda7b2a1fe)

running 30 tests
test commands::dedup::auto::tests::auto_dedup_prefers_branch_status_over_timestamp ... ok
test commands::dedup::compare::tests::comparator_prefers_top_level_pin_over_newer_transitive ... ok
test commands::dedup::auto::tests::restrict_to_seed_identity_drops_foreign_repositories ... ok
test commands::dedup::follows::tests::apply_follows_syncs_rev_and_lm_to_target ... ok
test fetch::auth::tests::credential_ladder_falls_back_only_for_credential_failures ... ok
test fetch::compare_planner::tests::dag_fallback_cause_surfaces_both_failures ... ok
test commands::dedup::compare::tests::compare_jobs_are_capped_before_network_work ... ok
test commands::dedup::compare::tests::classify_prefers_branch_status_over_timestamps ... ok
test fetch::compare_planner::tests::identical_compare_job_is_verified_without_network ... ok
test commands::dedup::scan::tests::scan_records_gitlab_locked_nodes ... ok
test commands::dedup::scan::tests::scan_reports_tack_lock_parse_failure_and_continues ... ok
test fetch::github::tests::parses_graphql_ref_compare_response ... ok
test fetch::resolve::tests::gitlab_git_url_checkout_stays_generic_git_lock ... ok
test fetch::resolve::tests::tarball_with_rev_drops_last_modified ... ok
test fetch::auth::tests::access_tokens_scrape_follows_include_and_later_lines_win ... ok
test fetch::resolve::tests::git_revision_read_trimmed_and_validated ... ok
test fetch::resolve::tests::path_pin_locks_absolute_targets_with_a_metadata_fingerprint ... ok
test lock::tests::remove_and_insert_replace_unknown_nodes ... ok
test lock::tests::extra_lock_fields_survive_node_roundtrip ... ok
test pins::tests::all_follows_array_form_implies_key_alias ... ok
test pins::tests::inputs_read_type_unpack_and_legacy_flake_from_each_entry ... ok
test source::id::tests::gitlab_identity_keeps_nested_groups_and_self_hosted_boundaries ... ok
test lock::tests::save_preserves_unknown_lock_nodes ... ok
test source::id::tests::source_identity_normalizes_common_url_and_lock_forms ... ok
test fetch::git_http::tests::unauthorized_request_resolves_credential_and_retries_with_authorization ... ok
test history::tests::undo_preserves_external_edits_as_redo_state ... ok
test history::tests::undo_then_redo_round_trips_state ... ok
test fetch::git::tests::pinned_rev_reachable_only_off_named_ref_is_found ... ok
test source::tests::localize_keeps_store_copied_path_urls_reachable ... ok
test fetch::git::dag::tests::compares_file_remote_topology ... ok

test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

     Running unittests src/main.rs (target/debug/deps/tack-e06cd369d632bf80)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests tack

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
</details>

*was tested locally on my Macbook*

Fixes #81