### PR TITLE
resolver: include metadata in fetch

### DIFF
--- a/.tack/default.nix
+++ b/.tack/default.nix
@@ -110,12 +110,13 @@ let
             src = raw;
             channelName = name;
           };
+          sourceInfo =
+            if (entry.unpack or "file") == "tarball" then
+              unpacked // { outPath = unpacked.outPath + "/" + name; }
+            else
+              raw;
         in
-        metadata
-        // {
-          outPath =
-            if (entry.unpack or "file") == "tarball" then unpacked.outPath + "/" + name else raw.outPath;
-        };
+        metadata // sourceInfo;
 
       resolveSpec =
         { upLock, spec }:
@@ -344,6 +345,7 @@ let
           f = followsFor pin;
         in
         metadata
+        // sourceInfo
         // (evalFlake {
           inherit sourceInfo flakeDir upLock;
           nodeName = rootNode;
@@ -383,7 +385,7 @@ let
           else
             trace "tack: ${path}: upstream .tack predates override support; overrides will not reach it" path
         else
-          metadata // { outPath = path; };
+          metadata // sourceInfo // { outPath = path; };
 
       loadPin =
         { name, pin }:

--- a/.tack/default.nix
+++ b/.tack/default.nix
@@ -345,7 +345,7 @@ let
           f = followsFor pin;
         in
         metadata
-        // sourceInfo
+        # // sourceInfo # already included by mkFlakeResult
         // (evalFlake {
           inherit sourceInfo flakeDir upLock;
           nodeName = rootNode;
@@ -373,6 +373,7 @@ let
               follows = f.level;
             })
           );
+          base = metadata // sourceInfo;
         in
         # only override tack files within a `fetch`, since there's no flake.lock
         if hasTack && tackOverrides != { } then
@@ -381,11 +382,13 @@ let
           in
           # old resolvers return a plain attrset, not a callable functor
           if upstream ? __functor then
-            (upstream { overrides = tackOverrides; }) // { outPath = path; }
+            base // (upstream { overrides = tackOverrides; }) // { outPath = path; }
           else
-            trace "tack: ${path}: upstream .tack predates override support; overrides will not reach it" path
+            trace "tack: ${path}: upstream .tack predates override support; overrides will not reach it" (
+              base // { outPath = path; }
+            )
         else
-          metadata // sourceInfo // { outPath = path; };
+          base // { outPath = path; };
 
       loadPin =
         { name, pin }:

--- a/.tack/default.nix
+++ b/.tack/default.nix
@@ -343,6 +343,7 @@ let
           sourceInfo,
           pin,
           subdir,
+          metadata,
         }:
         let
           path = sourceInfo.outPath + subdir;
@@ -369,7 +370,7 @@ let
           else
             trace "tack: ${path}: upstream .tack predates override support; overrides will not reach it" path
         else
-          path;
+          metadata // { outPath = path; };
 
       loadPin =
         { name, pin }:
@@ -389,7 +390,10 @@ let
           if pinType == "flake" then
             evalTopFlake { inherit sourceInfo pin; }
           else
-            evalFetch { inherit sourceInfo pin subdir; };
+            evalFetch {
+              inherit sourceInfo pin subdir;
+              metadata = lock.${name};
+            };
 
       declared = pins.inputs or { };
 

--- a/.tack/default.nix
+++ b/.tack/default.nix
@@ -88,7 +88,11 @@ let
             fetchTree node;
 
       fetchFixed =
-        { name, entry }:
+        {
+          name,
+          entry,
+          metadata,
+        }:
         let
           raw = derivation {
             inherit name;
@@ -107,7 +111,11 @@ let
             channelName = name;
           };
         in
-        if (entry.unpack or "file") == "tarball" then unpacked.outPath + "/" + name else raw.outPath;
+        metadata
+        // {
+          outPath =
+            if (entry.unpack or "file") == "tarball" then unpacked.outPath + "/" + name else raw.outPath;
+        };
 
       resolveSpec =
         { upLock, spec }:
@@ -384,10 +392,11 @@ let
         let
           pinType = pin.type or (if pin.flake or true then "flake" else "fetch");
           subdir = if pin ? dir then "/" + pin.dir else "";
+          metadata = lock.${name};
         in
         if pinType == "fixed" then
           fetchFixed {
-            inherit name;
+            inherit name metadata;
             entry = lock.${name};
           }
         else
@@ -395,14 +404,15 @@ let
             sourceInfo = fetchPin name;
           in
           if pinType == "flake" then
-            evalTopFlake {
-              inherit sourceInfo pin;
-              metadata = lock.${name};
-            }
+            evalTopFlake { inherit sourceInfo pin metadata; }
           else
             evalFetch {
-              inherit sourceInfo pin subdir;
-              metadata = lock.${name};
+              inherit
+                sourceInfo
+                pin
+                subdir
+                metadata
+                ;
             };
 
       declared = pins.inputs or { };

--- a/.tack/default.nix
+++ b/.tack/default.nix
@@ -323,7 +323,11 @@ let
         };
 
       evalTopFlake =
-        { sourceInfo, pin }:
+        {
+          sourceInfo,
+          pin,
+          metadata,
+        }:
         let
           flakeDir = sourceInfo.outPath + (if pin ? dir then "/" + pin.dir else "");
           upLockPath = flakeDir + "/flake.lock";
@@ -331,12 +335,15 @@ let
           rootNode = if upLock != null then upLock.root else null;
           f = followsFor pin;
         in
-        evalFlake {
+        {
+          _meta = metadata;
+        }
+        // (evalFlake {
           inherit sourceInfo flakeDir upLock;
           nodeName = rootNode;
           levelFollows = f.level;
           deepFollows = f.deep;
-        };
+        });
 
       evalFetch =
         {
@@ -388,7 +395,10 @@ let
             sourceInfo = fetchPin name;
           in
           if pinType == "flake" then
-            evalTopFlake { inherit sourceInfo pin; }
+            evalTopFlake {
+              inherit sourceInfo pin;
+              metadata = lock.${name};
+            }
           else
             evalFetch {
               inherit sourceInfo pin subdir;
@@ -410,14 +420,15 @@ let
         name:
         let
           sourceInfo = fetchPin name;
+          metadata = lock.${name};
         in
         if pathExists (sourceInfo.outPath + "/flake.nix") then
           evalTopFlake {
-            inherit sourceInfo;
+            inherit sourceInfo metadata;
             pin = { };
           }
         else
-          sourceInfo;
+          { _meta = metadata; } // sourceInfo;
 
       self =
         (mapAttrs (name: pin: loadPin { inherit name pin; }) declared)

--- a/.tack/default.nix
+++ b/.tack/default.nix
@@ -343,9 +343,7 @@ let
           rootNode = if upLock != null then upLock.root else null;
           f = followsFor pin;
         in
-        {
-          _meta = metadata;
-        }
+        metadata
         // (evalFlake {
           inherit sourceInfo flakeDir upLock;
           nodeName = rootNode;
@@ -438,7 +436,7 @@ let
             pin = { };
           }
         else
-          { _meta = metadata; } // sourceInfo;
+          metadata // sourceInfo;
 
       self =
         (mapAttrs (name: pin: loadPin { inherit name pin; }) declared)


### PR DESCRIPTION
closes #60 

Include metadata from pins.lock.json by default if pin.type = "fetch".
This mimics npins behavior to some degree.

I don't know if we should do something similar for "fixed" type. I don't think it's useful for "flake" type and it's kind of annoying to provide it by default.