### PR TITLE
update: add --exclude argument

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -97,9 +97,15 @@ impl<'a> Tack<'a> {
                 history_error = recorded.history_error;
                 CommandOutcome::Init
             },
-            Command::Update { names, accept } => {
-                let recorded =
-                    self.recorded(&label, || commands::update(self.project, &names, accept))?;
+            Command::Update {
+                exclude,
+                names,
+                accept,
+                ..
+            } => {
+                let recorded = self.recorded(&label, || {
+                    commands::update(self.project, &exclude, &names, accept)
+                })?;
                 captured_external = recorded.captured_external;
                 history_error = recorded.history_error;
                 CommandOutcome::Update(recorded.value)

--- a/src/app.rs
+++ b/src/app.rs
@@ -34,9 +34,13 @@ pub fn run(cmd: Command) -> eyre::Result<()> {
         Command::Dedup => commands::dedup(&project),
         Command::Undo { list } => commands::undo(&project, list),
         Command::Redo => commands::redo(&project),
-        Command::Update { names, accept } => {
+        Command::Update {
+            exclude,
+            names,
+            accept,
+        } => {
             recorded(&project, &label, || {
-                commands::update_cli(&project, &names, accept)
+                commands::update_cli(&project, &exclude, &names, accept)
             })
         },
         Command::Add {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,8 +17,9 @@ pub enum Command {
         convert:  bool,
     },
     Update {
-        names:  Vec<String>,
-        accept: bool,
+        exclude: Vec<String>,
+        names:   Vec<String>,
+        accept:  bool,
     },
     Look {
         names:   Vec<String>,
@@ -71,9 +72,12 @@ enum Cli {
     Update {
         /// relock drifted pins instead of failing
         #[pound(long)]
-        accept: bool,
+        accept:  bool,
+        /// exclude pins from update (e.g. "nixpkgs, home-manager")
+        #[pound(long)]
+        exclude: Option<String>,
         /// pins to update (default: all)
-        names:  Vec<String>,
+        names:   Vec<String>,
     },
     /// show upstream drift without writing the lock
     Look {
@@ -198,7 +202,19 @@ impl From<Cli> for Command {
                     convert,
                 }
             },
-            Cli::Update { accept, names } => Self::Update { names, accept },
+            Cli::Update {
+                accept,
+                exclude,
+                names,
+            } => {
+                Self::Update {
+                    names,
+                    exclude: exclude
+                        .map(|name| name.split(',').map(|i| i.trim().to_owned()).collect())
+                        .unwrap_or_default(),
+                    accept,
+                }
+            },
             Cli::Look { verbose, names } => Self::Look { names, verbose },
             Cli::Add {
                 name,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -90,16 +90,26 @@ pub fn alias(project: &Project, name: &str, template: Option<&str>, remove: bool
     edit::alias(project, name, template, remove)
 }
 
-pub fn update(project: &Project, names: &[String], accept: bool) -> Result<UpdateReport> {
-    update::update(project, names, accept)
+pub fn update(
+    project: &Project,
+    exclude: &[String],
+    names: &[String],
+    accept: bool,
+) -> Result<UpdateReport> {
+    update::update(project, exclude, names, accept)
 }
 
 pub fn look(project: &Project, names: &[String], verbose: bool) -> Result<LookReport> {
     update::look(project, names, verbose)
 }
 
-pub fn update_cli(project: &Project, names: &[String], accept: bool) -> Result<()> {
-    update::update_cli(project, names, accept)
+pub fn update_cli(
+    project: &Project,
+    exclude: &[String],
+    names: &[String],
+    accept: bool,
+) -> Result<()> {
+    update::update_cli(project, exclude, names, accept)
 }
 
 pub fn look_cli(project: &Project, names: &[String], verbose: bool) -> Result<()> {
@@ -144,14 +154,24 @@ fn tolerate<T>(result: StdResult<T, FetchError>) -> (Option<T>, Option<String>) 
     }
 }
 
-fn select<'a>(inputs: &'a [pins::Input], names: &[String]) -> Vec<&'a pins::Input> {
+fn select<'a>(
+    inputs: &'a [pins::Input],
+    exclude: &[String],
+    names: &[String],
+) -> Vec<&'a pins::Input> {
+    let filtered: Vec<_> = inputs
+        .iter()
+        .filter(|i| !exclude.contains(&i.name))
+        .collect();
+
     if names.is_empty() {
-        return inputs.iter().collect();
+        return filtered;
     }
+
     let mut out = Vec::new();
     for n in names {
-        match inputs.iter().find(|i| &i.name == n) {
-            Some(i) => out.push(i),
+        match filtered.iter().find(|i| &i.name == n) {
+            Some(i) => out.push(*i),
             None => eprintln!("no input '{n}'"),
         }
     }

--- a/src/commands/update/core.rs
+++ b/src/commands/update/core.rs
@@ -276,6 +276,7 @@ fn pin_names(selected: &[&pins::Input]) -> Vec<String> {
 
 pub(super) fn update(
     project: &Project,
+    exclude: &[String],
     names: &[String],
     accept: bool,
     progress: &impl Progress<UpdateOutcome>,
@@ -284,7 +285,7 @@ pub(super) fn update(
     let shorturls = doc.shorturls();
     let all = doc.inputs()?;
     let all_follow = doc.all_follows()?;
-    let selected = select(&all, names);
+    let selected = select(&all, exclude, names);
     if selected.is_empty() {
         return Ok(UpdateReport::default());
     }
@@ -413,7 +414,7 @@ pub(super) fn look(
     let doc = project.load_pins()?;
     let shorturls = doc.shorturls();
     let all = doc.inputs()?;
-    let selected = select(&all, names);
+    let selected = select(&all, &[], names);
     if selected.is_empty() {
         return Ok(LookReport::default());
     }

--- a/src/commands/update/mod.rs
+++ b/src/commands/update/mod.rs
@@ -137,13 +137,23 @@ impl<O> core::Progress<O> for SpinnerProgress<'_, O> {
     }
 }
 
-pub fn update(project: &Project, names: &[String], accept: bool) -> Result<UpdateReport> {
-    core::update(project, names, accept, &core::NoProgress)
+pub fn update(
+    project: &Project,
+    exclude: &[String],
+    names: &[String],
+    accept: bool,
+) -> Result<UpdateReport> {
+    core::update(project, exclude, names, accept, &core::NoProgress)
 }
 
-pub fn update_cli(project: &Project, names: &[String], accept: bool) -> Result<()> {
+pub fn update_cli(
+    project: &Project,
+    exclude: &[String],
+    names: &[String],
+    accept: bool,
+) -> Result<()> {
     let spinner = Spinner::new();
-    let report = core::update(project, names, accept, &SpinnerProgress {
+    let report = core::update(project, exclude, names, accept, &SpinnerProgress {
         spinner: &spinner,
         status:  update_status,
     })?;


### PR DESCRIPTION
Adds a `--exclude` argument to update. E.g. `tack update --exclude nixpkgs,home-manager`. I chose the comma separated string instead of a repeatable argument as multiple `--exclude` is a pain to type.