### PR TITLE
dedup: use revs for tarball source_identity if available

### DIFF
--- a/src/lock.rs
+++ b/src/lock.rs
@@ -483,7 +483,11 @@ impl LockedNode {
             Self::Github { rev, .. } | Self::Gitlab { rev, .. } | Self::Git { rev, .. } => {
                 rev.as_deref().map(LockIdentity::Rev)
             },
-            Self::Tarball { url, .. } => Some(LockIdentity::ImmutableUrl(url)),
+            Self::Tarball { url, rev, .. } => {
+                rev.as_deref()
+                    .map(LockIdentity::Rev)
+                    .or(Some(LockIdentity::ImmutableUrl(url)))
+            },
             Self::Fixed { url, sha256, .. } => {
                 url.as_deref()
                     .map(LockIdentity::SourceUrl)


### PR DESCRIPTION
`tack dedup` was using a tarball's `url` as its `rev`, causing a malformed call to the github api and the inability to compare pins:
```
scanning 4 pin(s)...
tack: https://api.github.com/repos/nixos/nixpkgs/compare/d482ef84049d9b7276b83a06e4e4d76983830097...https://releases.nixos.org/nixos/unstable/nixos-26.11pre1064949.34ab99075ac4/nixexprs.tar.xz?per_page=1 not found
tack: 1 branch comparison(s) unavailable or capped; falling back to commit-date order

github:nixos/nixpkgs  x3
  d482ef8          = nixpkgs  autolith
  nixos-26.11pre10   nixpkgs  agenix
                              disko
```

When available, prefer `rev` over `url`, so we can properly feed the `rev` into the github api call:

```
scanning 4 pin(s)...

github:nixos/nixpkgs  x3
  34ab990 ↑ nixpkgs  agenix
                     disko
  d482ef8 = nixpkgs  autolith
```

---

I am not very familiar with rust, but figured I'd give a shot at a small fix like this. Main thing that hung me up was if I should use `.or_else` instead of `.or`, but clippy wasn't complaining so I stuck with this.  The only side-effect I've noticed is that the `nixos-26.11pre...` prefix gets filtered out. 